### PR TITLE
Add service item table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# takip_sistemi
+# Takip Sistemi
+
+Bu proje, domain ve hosting hizmetlerini takip etmek için basit bir PHP panelidir.
+
+## Kurulum
+
+1. `sql/schema.sql` dosyasındaki tabloları MySQL veritabanınıza aktarın.
+2. `config/config.php` dosyasında yer alan veritabanı ve SMTP bilgilerini gerekirse güncelleyin.
+3. Depo kök dizinini web sunucunuzun kök dizini olarak ayarlayın.
+
+İlk giriş için veritabanına varsayılan bir kullanıcı eklenmiştir:
+
+- E‑posta: `info@precadmedya.com.tr`
+- Şifre: `123456`
+
+## Sayfalar
+
+- `/login.php` – Oturum açma ekranı
+- `/dashboard.php` – Anasayfa, iki sütunlu takvim ve yaklaşan hizmet listesi
+- `/customers.php` – Müşteri listesi
+ - `/customer_payment.php` – Müşteri tahsilatı (isteğe bağlı hizmet seçilebilir)
+- `/customer.php` – Müşterinin detaylı sayfası, geçmiş ödemeler ve yaklaşan borçlar
+- `/customer_statement.php` – Müşteri ekstresi (CSV indirme)
+ - `/customer_add.php` – Müşteri ekleme formu
+ - `/customer_edit.php` – Müşteri düzenleme
+ - `/customer_delete.php` – Müşteri silme
+ - `/services.php` – Hizmet listesi
+ - `/service_payment.php` – Hizmet tahsilatı ve yenileme
+   (mevcut borcu görüntüler ve ödeme sonrası uzatma seçeneği sunar)
+- `/service_add.php` – Hizmet ekleme formu (başlangıç ve ödeme tarihleri seçilebilir)
+  (formun altında hizmet/ürün satırları ekleyerek faturaya benzer kalemler oluşturabilirsiniz)
+ - `/service_edit.php` – Hizmet düzenleme
+ - `/service_delete.php` – Hizmet silme
+ - `/service.php` – Hizmet detayları ve tahsilat geçmişi
+- `/payment_edit.php` – Tahsilat düzenleme
+- `/payment_delete.php` – Tahsilat silme
+- `/products.php` – Ürün yönetimi
+- `/providers.php` – Sağlayıcı yönetimi
+- `/users.php` – Kullanıcı yönetimi
+- `/settings.php` – Logo ve boyut ayarları
+- `/exchange_rates_cron.php` – Günlük kur çekme işlemi
+- `/exchange_rates.php` – Kur geçmişi listesi
+
+`exchange_rates_cron.php` dosyası her gün çalıştırılarak TCMB'den USD kurunun
+güncel değerini `exchange_rates` tablosuna kaydeder. Cron örneği:
+
+```
+0 9 * * * php /path/to/exchange_rates_cron.php >/dev/null 2>&1
+```
+
+Müşteri listesi sayfasında her müşterinin TL cinsinden bakiyesi görüntülenir. USD olarak kaydedilmiş hizmet bedelleri, sistemdeki en güncel kura göre TL'ye dönüştürülerek hesaplanır. Tahsilatlar hem müşteri hem de hizmet bazında kaydedilir ve bakiye bu ödemeler düşülerek hesaplanır.
+
+Tüm arayüz Türkçe olup Bootstrap 5 kullanılarak oluşturulmuştur. Sayfalara erişmek için oturum açmak gereklidir.
+Logo yükleme sayfasında giriş ve üst menüde kullanılacak logonun boyutları ayarlanabilir.
+
+Veritabanında `payments` tablosu tahsilat kayıtlarını tutar ve `exchange_rates` tablosundaki güncel dolar kuru kullanılarak USD tahsilatları otomatik TL'ye çevrilir.
+Her hizmet için ek kalemlerin saklandığı `service_items` tablosu da bulunmaktadır. Bu tabloda artık her kalemin döviz türü ve sağlayıcısı da saklanır.
+Hizmet kayıtlarında hem orijinal para birimi hem de TL karşılığı saklanır ve ödeme tarihi alanı bulunur.
+
+Dashboard sayfasında aylık görünümlü bir takvim ile yaklaşan hizmet bitişleri aynı sayfada iki sütun olarak gösterilir. Takvimde hizmet tarihi olan günler renkli çubuklarla işaretlenir ve tıklandığında o güne ait hizmetler modal pencerede açılır. Sağdaki listede en yakın on hizmet bitişi arama kutusuyla filtrelenebilir. Alt bölümde en çok satan ve son eklenen hizmetler yer alır.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Bu proje, domain ve hosting hizmetlerini takip etmek için basit bir PHP panelid
  - `/services.php` – Hizmet listesi
  - `/service_payment.php` – Hizmet tahsilatı ve yenileme
    (mevcut borcu görüntüler ve ödeme sonrası uzatma seçeneği sunar)
-- `/service_add.php` – Hizmet ekleme formu (başlangıç ve ödeme tarihleri seçilebilir)
-  (formun altında hizmet/ürün satırları ekleyerek faturaya benzer kalemler oluşturabilirsiniz)
+ - `/service_add.php` – Hizmet ekleme formu. Ürün satırında seçim yapıldığında fiyat, döviz ve KDV otomatik dolar.
+   Listede olmayan ürünler eklenmek istendiğinde form, ürünü ürünler sayfasına kaydetmeyi teklif eder. Satırlardan elde edilen toplam otomatik hesaplanır.
  - `/service_edit.php` – Hizmet düzenleme
  - `/service_delete.php` – Hizmet silme
  - `/service.php` – Hizmet detayları ve tahsilat geçmişi

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,17 @@
+<?php
+return [
+    'db' => [
+        'host' => getenv('DB_HOST') ?: 'localhost',
+        'dbname' => getenv('DB_NAME') ?: 'precadme_takip',
+        'user' => getenv('DB_USER') ?: 'precadme_takip',
+        'pass' => getenv('DB_PASS') ?: 'Kolega3452323',
+        'charset' => 'utf8mb4'
+    ],
+    'smtp' => [
+        'host' => getenv('SMTP_HOST') ?: 'smtp.yandex.com.tr',
+        'port' => getenv('SMTP_PORT') ?: 465,
+        'encryption' => getenv('SMTP_ENCRYPTION') ?: 'ssl',
+        'username' => getenv('SMTP_USER') ?: 'info@precadmedya.com.tr',
+        'password' => getenv('SMTP_PASS') ?: 'Precadmedya34523'
+    ]
+];

--- a/customer.php
+++ b/customer.php
@@ -1,0 +1,123 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
+$stmt->execute([$id]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$customer){
+    header('Location: /customers.php');
+    exit;
+}
+
+$svcStmt = $pdo->prepare('SELECT s.*, p.name AS product_name, pr.name AS provider_name,
+    IFNULL((SELECT SUM(amount_try) FROM payments WHERE service_id=s.id),0) AS paid_try
+    FROM services s
+    LEFT JOIN products p ON s.product_id=p.id
+    LEFT JOIN providers pr ON s.provider_id=pr.id
+    WHERE s.customer_id=? ORDER BY s.id DESC');
+$svcStmt->execute([$id]);
+$services = $svcStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$payStmt = $pdo->prepare('SELECT p.*, s.site_name FROM payments p
+    LEFT JOIN services s ON p.service_id=s.id
+    WHERE p.customer_id=? ORDER BY p.created_at DESC');
+$payStmt->execute([$id]);
+$payments = $payStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$usdRate = getUsdRate($pdo);
+$totalDebt = 0;
+$upcoming = [];
+foreach($services as &$s){
+    $s['total_try'] = $s['price_try'] * (1 + $s['vat_rate']/100);
+    $s['remaining'] = $s['total_try'] - $s['paid_try'];
+    if($s['remaining'] > 0){
+        $totalDebt += $s['remaining'];
+        if(strtotime($s['due_date']) <= strtotime('+30 days')){
+            $upcoming[] = $s;
+        }
+    }
+}
+unset($s);
+
+include __DIR__.'/includes/header.php';
+?>
+<h1><?= htmlspecialchars($customer['full_name']) ?></h1>
+<p>E-Posta: <?= htmlspecialchars($customer['email']) ?></p>
+<p>Telefon: <?= htmlspecialchars($customer['phone']) ?></p>
+<p>Şirket: <?= htmlspecialchars($customer['company']) ?></p>
+<p>Adres: <?= nl2br(htmlspecialchars($customer['address'])) ?></p>
+<a href="/customer_payment.php?customer_id=<?= $id ?>" class="btn btn-success mb-3">Tahsilat Yap</a>
+<a href="/customer_edit.php?id=<?= $id ?>" class="btn btn-warning mb-3">Düzenle</a>
+<a href="/customer_delete.php?id=<?= $id ?>" class="btn btn-danger mb-3" onclick="return confirm('Silinsin mi?');">Sil</a>
+<a href="/customer_statement.php?id=<?= $id ?>" class="btn btn-secondary mb-3">Ekstre İndir</a>
+<div class="row mb-4">
+ <div class="col-md-6">
+  <div class="card text-bg-light mb-3">
+   <div class="card-body">
+    <h5 class="card-title">Toplam Borç</h5>
+    <p class="card-text fw-bold"><?= number_format($totalDebt,2,',','.') ?> ₺</p>
+   </div>
+  </div>
+ </div>
+ <div class="col-md-6">
+  <div class="card text-bg-light mb-3">
+   <div class="card-body">
+    <h5 class="card-title">Yaklaşan Ödemeler (30 gün)</h5>
+    <?php if($upcoming): ?>
+    <ul class="mb-0">
+     <?php foreach($upcoming as $u): ?>
+     <li><?= htmlspecialchars($u['site_name']) ?> - <?= date('d.m.Y', strtotime($u['due_date'])) ?> - <?= number_format($u['remaining'],2,',','.') ?> ₺</li>
+     <?php endforeach; ?>
+    </ul>
+    <?php else: ?>
+    <p class="mb-0">Yaklaşan ödeme yok</p>
+    <?php endif; ?>
+   </div>
+  </div>
+ </div>
+</div>
+<h2>Hizmetleri</h2>
+<table class="table table-bordered">
+ <thead>
+  <tr>
+   <th>Ürün</th><th>Site</th><th>Ödeme Tarihi</th><th>Fiyat</th><th>Ödenen</th><th>Kalan</th><th>İşlem</th>
+  </tr>
+ </thead>
+ <tbody>
+ <?php foreach($services as $s): ?>
+  <tr>
+   <td><?= htmlspecialchars($s['product_name']) ?></td>
+   <td><?= htmlspecialchars($s['site_name']) ?></td>
+   <td><?= date('d.m.Y', strtotime($s['due_date'])) ?></td>
+   <td><?= number_format($s['total_try'],2,',','.') ?> ₺</td>
+   <td><?= number_format($s['paid_try'],2,',','.') ?> ₺</td>
+   <td><?= number_format($s['remaining'],2,',','.') ?> ₺</td>
+   <td>
+    <a href="/service.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-info">Detay</a>
+    <a href="/service_payment.php?service_id=<?= $s['id'] ?>" class="btn btn-sm btn-primary">Tahsilat</a>
+    <a href="/service_edit.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+    <a href="/service_delete.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+   </td>
+  </tr>
+ <?php endforeach; ?>
+ </tbody>
+</table>
+<h2>Tahsilatlar</h2>
+<table class="table table-bordered">
+ <thead>
+  <tr><th>Hizmet/Site</th><th>Tutar (TL)</th><th>Para Birimi</th><th>Tarih</th></tr>
+ </thead>
+ <tbody>
+  <?php foreach($payments as $p): ?>
+  <tr>
+   <td><?= htmlspecialchars($p['site_name']) ?></td>
+   <td><?= number_format($p['amount_try'],2,',','.') ?> ₺</td>
+   <td><?= htmlspecialchars($p['currency']) ?></td>
+   <td><?= date('d.m.Y', strtotime($p['created_at'])) ?></td>
+  </tr>
+  <?php endforeach; ?>
+ </tbody>
+</table>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/customer_add.php
+++ b/customer_add.php
@@ -1,0 +1,43 @@
+<?php
+require __DIR__.'/includes/auth.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare("INSERT INTO customers (full_name, email, phone, company, address, created_at) VALUES (?, ?, ?, ?, ?, NOW())");
+    $stmt->execute([
+        $_POST['full_name'],
+        $_POST['email'],
+        $_POST['phone'],
+        $_POST['company'],
+        $_POST['address']
+    ]);
+    header('Location: /customers.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Müşteri Ekle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ad Soyad</label>
+    <input type="text" name="full_name" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">E-Posta</label>
+    <input type="email" name="email" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Telefon</label>
+    <input type="text" name="phone" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Şirket</label>
+    <input type="text" name="company" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Adres</label>
+    <textarea name="address" class="form-control"></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/customer_delete.php
+++ b/customer_delete.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__.'/includes/auth.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('DELETE FROM customers WHERE id=?');
+$stmt->execute([$id]);
+header('Location: /customers.php');
+exit;

--- a/customer_edit.php
+++ b/customer_edit.php
@@ -1,0 +1,54 @@
+<?php
+require __DIR__.'/includes/auth.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
+$stmt->execute([$id]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$customer){
+    header('Location: /customers.php');
+    exit;
+}
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $stmt = $pdo->prepare('UPDATE customers SET full_name=?, email=?, phone=?, company=?, address=? WHERE id=?');
+    $stmt->execute([
+        $_POST['full_name'],
+        $_POST['email'],
+        $_POST['phone'],
+        $_POST['company'],
+        $_POST['address'],
+        $id
+    ]);
+    header('Location: /customers.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Müşteri Düzenle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ad Soyad</label>
+    <input type="text" name="full_name" class="form-control" value="<?= htmlspecialchars($customer['full_name']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">E-Posta</label>
+    <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($customer['email']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Telefon</label>
+    <input type="text" name="phone" class="form-control" value="<?= htmlspecialchars($customer['phone']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Şirket</label>
+    <input type="text" name="company" class="form-control" value="<?= htmlspecialchars($customer['company']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Adres</label>
+    <textarea name="address" class="form-control"><?= htmlspecialchars($customer['address']) ?></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="/customers.php" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/customer_payment.php
+++ b/customer_payment.php
@@ -1,0 +1,61 @@
+<?php
+require __DIR__.'/includes/auth.php';
+
+$customer_id = isset($_GET['customer_id']) ? (int)$_GET['customer_id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
+$stmt->execute([$customer_id]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$customer){
+    header('Location: /customers.php');
+    exit;
+}
+
+$rateStmt = $pdo->query("SELECT usd_try FROM exchange_rates ORDER BY rate_date DESC LIMIT 1");
+$usdRate = (float)$rateStmt->fetchColumn();
+$services = $pdo->prepare('SELECT id, service_type, site_name FROM services WHERE customer_id=? ORDER BY id DESC');
+$services->execute([$customer_id]);
+$services = $services->fetchAll(PDO::FETCH_ASSOC);
+$balStmt = $pdo->prepare("SELECT IFNULL(SUM(s.price_try*(1+s.vat_rate/100)),0) - IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.customer_id=c.id),0) FROM customers c LEFT JOIN services s ON s.customer_id=c.id WHERE c.id=? GROUP BY c.id");
+$balStmt->execute([$customer_id]);
+$balance = (float)$balStmt->fetchColumn();
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $amount = (float)$_POST['amount'];
+    $currency = $_POST['currency'];
+    $serviceId = !empty($_POST['service_id']) ? (int)$_POST['service_id'] : null;
+    $amount_try = $currency === 'USD' ? $amount * $usdRate : $amount;
+    $stmt = $pdo->prepare('INSERT INTO payments (customer_id, service_id, amount_try, amount_orig, currency) VALUES (?,?,?,?,?)');
+    $stmt->execute([$customer_id, $serviceId, $amount_try, $amount, $currency]);
+    header('Location: /customers.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Tahsilat Yap - <?= htmlspecialchars($customer['full_name']) ?></h1>
+<p><strong>Toplam Borç:</strong> <?= number_format($balance,2,',','.') ?> ₺</p>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Hizmet (opsiyonel)</label>
+    <select name="service_id" class="form-control">
+      <option value="">Genel</option>
+      <?php foreach($services as $s): ?>
+      <option value="<?= $s['id'] ?>"><?= htmlspecialchars($s['service_type'].' - '.$s['site_name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Tutar</label>
+    <input type="text" name="amount" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Para Birimi</label>
+    <select name="currency" class="form-control">
+      <option value="TRY">TL</option>
+      <option value="USD">USD</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="/customers.php" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/customer_statement.php
+++ b/customer_statement.php
@@ -1,0 +1,26 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
+$stmt->execute([$id]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$customer){
+    exit('Müşteri bulunamadı');
+}
+header('Content-Type: text/csv; charset=utf-8');
+header('Content-Disposition: attachment; filename=statement_'.$id.'.csv');
+$out = fopen('php://output','w');
+fputcsv($out,['Tarih','Açıklama','Tutar (TL)']);
+$svcStmt = $pdo->prepare('SELECT site_name,due_date,price_try,vat_rate FROM services WHERE customer_id=?');
+$svcStmt->execute([$id]);
+while($s = $svcStmt->fetch(PDO::FETCH_ASSOC)){
+    $total = $s['price_try']*(1+$s['vat_rate']/100);
+    fputcsv($out,[date('d.m.Y',strtotime($s['due_date'])),'Hizmet: '.$s['site_name'],$total]);
+}
+$payStmt = $pdo->prepare('SELECT amount_try,currency,created_at FROM payments WHERE customer_id=?');
+$payStmt->execute([$id]);
+while($p = $payStmt->fetch(PDO::FETCH_ASSOC)){
+    fputcsv($out,[date('d.m.Y',strtotime($p['created_at'])),'Tahsilat',$p['amount_try']*-1]);
+}
+fclose($out);

--- a/customers.php
+++ b/customers.php
@@ -1,0 +1,51 @@
+<?php
+require __DIR__.'/includes/auth.php';
+include __DIR__.'/includes/header.php';
+
+$stmt = $pdo->query("SELECT c.*, 
+    IFNULL(SUM(s.price_try * (1 + s.vat_rate/100)),0) - 
+    IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.customer_id=c.id),0) AS balance
+    FROM customers c
+    LEFT JOIN services s ON s.customer_id = c.id
+    GROUP BY c.id
+    ORDER BY c.id DESC");
+$customers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h1>Müşteriler</h1>
+<a href="/customer_add.php" class="btn btn-primary mb-3">Müşteri Ekle</a>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+       <th>ID</th>
+       <th>Ad Soyad</th>
+       <th>E-Posta</th>
+       <th>Telefon</th>
+       <th>Şirket</th>
+       <th>Adres</th>
+       <th>Bakiye (TL)</th>
+       <th>Oluşturma</th>
+       <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($customers as $c): ?>
+    <tr>
+      <td><?= htmlspecialchars($c['id']) ?></td>
+      <td><?= htmlspecialchars($c['full_name']) ?></td>
+      <td><?= htmlspecialchars($c['email']) ?></td>
+      <td><?= htmlspecialchars($c['phone']) ?></td>
+      <td><?= htmlspecialchars($c['company']) ?></td>
+      <td><?= htmlspecialchars($c['address']) ?></td>
+      <td><?= number_format($c['balance'], 2, ',', '.') ?> ₺</td>
+      <td><?= date('d.m.Y', strtotime($c['created_at'])) ?></td>
+      <td>
+        <a href="/customer.php?id=<?= $c['id'] ?>" class="btn btn-sm btn-info">Detay</a>
+        <a href="/customer_payment.php?customer_id=<?= $c['id'] ?>" class="btn btn-sm btn-success">Tahsilat</a>
+        <a href="/customer_edit.php?id=<?= $c['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="/customer_delete.php?id=<?= $c['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,192 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$year = isset($_GET['y']) ? (int)$_GET['y'] : (int)date('Y');
+$month = isset($_GET['m']) ? (int)$_GET['m'] : (int)date('n');
+$startMonth = sprintf('%04d-%02d-01', $year, $month);
+$endMonth = date('Y-m-t', strtotime($startMonth));
+
+$events = [];
+$monthTotal = 0;
+$rows = $pdo->query("SELECT s.id,s.site_name,c.full_name,s.due_date,
+ (s.price_try*(1+s.vat_rate/100) - IFNULL((SELECT SUM(amount_try) FROM payments WHERE service_id=s.id),0)) AS remain
+ FROM services s JOIN customers c ON s.customer_id=c.id")->fetchAll(PDO::FETCH_ASSOC);
+foreach($rows as $r){
+    if($r['remain']<=0) continue;
+    if($r['due_date'] >= $startMonth && $r['due_date'] <= $endMonth){
+        $day = (int)date('j', strtotime($r['due_date']));
+        $events[$day][] = $r;
+        $monthTotal += $r['remain'];
+    } elseif(date('Y-m',strtotime($r['due_date']))==date('Y-m')) {
+        $monthTotal += $r['remain'];
+    }
+}
+
+$overallTotal = (float)$pdo->query("SELECT SUM(s.price_try*(1+s.vat_rate/100) - IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.service_id=s.id),0)) FROM services s")->fetchColumn();
+$customerCount = (int)$pdo->query("SELECT COUNT(*) FROM customers")->fetchColumn();
+$serviceCount = (int)$pdo->query("SELECT COUNT(*) FROM services")->fetchColumn();
+$topServices = $pdo->query("SELECT service_type, COUNT(*) c FROM services GROUP BY service_type ORDER BY c DESC LIMIT 5")->fetchAll(PDO::FETCH_ASSOC);
+$recent = $pdo->query("SELECT s.id,c.full_name,s.site_name FROM services s JOIN customers c ON s.customer_id=c.id ORDER BY s.created_at DESC LIMIT 5")->fetchAll(PDO::FETCH_ASSOC);
+$rateRow = $pdo->query("SELECT rate_date, usd_try FROM exchange_rates ORDER BY rate_date DESC LIMIT 1")->fetch(PDO::FETCH_ASSOC);
+
+$upcoming = $pdo->query("SELECT s.id,s.site_name,c.full_name,s.due_date FROM services s JOIN customers c ON s.customer_id=c.id WHERE s.due_date >= CURDATE() ORDER BY s.due_date ASC LIMIT 10")->fetchAll(PDO::FETCH_ASSOC);
+
+$months = ['Ocak','Şubat','Mart','Nisan','Mayıs','Haziran','Temmuz','Ağustos','Eylül','Ekim','Kasım','Aralık'];
+$monthName = $months[$month-1];
+$prevM = $month-1; $prevY = $year; if($prevM<1){$prevM=12;$prevY--;}
+$nextM = $month+1; $nextY = $year; if($nextM>12){$nextM=1;$nextY++;}
+$startDow = (int)date('N', strtotime($startMonth)); // 1=Mon
+$daysInMonth = (int)date('t', strtotime($startMonth));
+$weeks = ceil(($startDow-1 + $daysInMonth)/7);
+
+$eventsJs = [];
+foreach($events as $d=>$evs){
+    foreach($evs as $e){
+        $eventsJs[$d][] = ['site'=>$e['site_name'],'customer'=>$e['full_name'],'due'=>$e['due_date']];
+    }
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Anasayfa</h1>
+<div class="row mb-4">
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Bu Ay Alınacak</h5><p class="card-text fw-bold"><?= number_format($monthTotal,2,',','.') ?> ₺</p></div></div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Toplam Alacak</h5><p class="card-text fw-bold"><?= number_format($overallTotal,2,',','.') ?> ₺</p></div></div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Müşteri Sayısı</h5><p class="card-text fw-bold"><?= $customerCount ?></p></div></div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Hizmet Sayısı</h5><p class="card-text fw-bold"><?= $serviceCount ?></p></div></div>
+  </div>
+  <?php if ($rateRow): ?>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Güncel Kur</h5><p class="card-text fw-bold"><?= number_format($rateRow['usd_try'],4,',','.') ?> (<?= htmlspecialchars($rateRow['rate_date']) ?>)</p></div></div>
+  </div>
+  <?php endif; ?>
+</div>
+<div class="row">
+  <div class="col-lg-8 mb-4">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <div>
+        <a class="btn btn-sm btn-outline-secondary" href="?y=<?= $prevY ?>&m=<?= $prevM ?>">&lt;</a>
+        <strong class="mx-2"><?= $monthName.' '.$year ?></strong>
+        <a class="btn btn-sm btn-outline-secondary" href="?y=<?= $nextY ?>&m=<?= $nextM ?>">&gt;</a>
+      </div>
+      <a class="btn btn-sm btn-outline-primary" href="?">Bugün</a>
+    </div>
+    <table class="table calendar table-bordered text-center">
+      <thead><tr><th>Pzt</th><th>Sal</th><th>Çar</th><th>Per</th><th>Cum</th><th>Cmt</th><th>Paz</th></tr></thead>
+      <tbody>
+      <?php
+      $day = 1 - ($startDow-1);
+      for($w=0;$w<$weeks;$w++):
+          echo "<tr>";
+          for($d=1;$d<=7;$d++):
+              if($day<1 || $day>$daysInMonth){
+                  echo '<td class="bg-light"></td>';
+              } else {
+                  $has = !empty($events[$day]);
+                  echo '<td class="calendar-day" data-day="'.$day.'">';
+                  echo '<div class="day-number">'.$day.'</div>';
+                  if($has){
+                      foreach($events[$day] as $ev){
+                          $diff = floor((strtotime($ev['due_date'])-time())/86400);
+                          $cls = $diff<0?'bg-danger':($diff<=14?'bg-orange':($diff<=30?'bg-warning':'bg-success'));
+                          echo '<div class="event '.$cls.'" title="'.htmlspecialchars($ev['site_name'],ENT_QUOTES).'"></div>';
+                      }
+                  }
+                  echo '</td>';
+              }
+              $day++;
+          endfor;
+          echo "</tr>";
+      endfor;
+      ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="col-lg-4">
+    <input type="text" id="search" class="form-control mb-2" placeholder="Veriler içinde arama yap">
+    <div class="list-group" id="upcomingList" style="max-height:400px;overflow:auto;">
+      <?php foreach($upcoming as $u):
+            $diff=floor((strtotime($u['due_date'])-time())/86400);
+            $cls=$diff<0?'bg-danger':($diff<=14?'bg-orange':($diff<=30?'bg-warning':'bg-success'));
+            $txt=$diff>=0?'+'.$diff.' gün kaldı':abs($diff).' gün geçti';
+      ?>
+      <a href="/service.php?id=<?= $u['id'] ?>" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" data-search="<?= strtolower($u['site_name'].' '.$u['full_name']) ?>">
+        <span>
+          <strong><?= htmlspecialchars($u['site_name']) ?></strong><br>
+          <small><?= htmlspecialchars($u['full_name']) ?></small>
+        </span>
+        <span class="badge text-light <?= $cls ?>"><?= $txt ?></span>
+      </a>
+      <?php endforeach; ?>
+    </div>
+  </div>
+</div>
+<div class="modal fade" id="dayModal" tabindex="-1">
+  <div class="modal-dialog"><div class="modal-content">
+    <div class="modal-header"><h5 class="modal-title">Gün Detayları</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+    <div class="modal-body" id="dayModalBody"></div>
+  </div></div>
+</div>
+<h2 class="mt-5">Analizler</h2>
+<div class="row">
+ <div class="col-md-6">
+  <h4>En Çok Satan Hizmetler</h4>
+  <ul>
+   <?php foreach($topServices as $t): ?>
+    <li><?= htmlspecialchars($t['service_type']) ?> (<?= $t['c'] ?>)</li>
+   <?php endforeach; ?>
+  </ul>
+ </div>
+ <div class="col-md-6">
+  <h4>Son Eklenen Hizmetler</h4>
+  <ul>
+   <?php foreach($recent as $r): ?>
+    <li><a href="/service.php?id=<?= $r['id'] ?>"><?= htmlspecialchars($r['full_name'].' - '.$r['site_name']) ?></a></li>
+   <?php endforeach; ?>
+  </ul>
+ </div>
+</div>
+<style>
+.calendar{background:#fff;border-radius:8px;box-shadow:0 5px 15px rgba(0,0,0,0.1);} 
+.calendar-day{height:80px;vertical-align:top;cursor:pointer;transition:transform .2s;}
+.calendar-day:hover{transform:scale(1.05);} 
+.day-number{font-weight:500;text-align:right;}
+.event{height:6px;border-radius:3px;margin-top:2px;}
+.bg-orange{background-color:#fd7e14!important;color:#fff;}
+</style>
+<script>
+var events = <?= json_encode($eventsJs) ?>;
+document.querySelectorAll('.calendar-day').forEach(function(td){
+  td.addEventListener('click',function(){
+    var d=this.dataset.day;
+    if(!events[d]) return;
+    var html='';
+    events[d].forEach(function(ev){
+      var due=new Date(ev.due);
+      var today=new Date();
+      today.setHours(0,0,0,0);
+      var diff=Math.floor((due-today)/86400000);
+      var txt=(diff>=0?"+"+diff+" gün kaldı":Math.abs(diff)+" gün geçti");
+      html+='<p><strong>'+ev.site+'</strong> - '+ev.customer+' ('+txt+')</p>';
+    });
+    document.getElementById('dayModalBody').innerHTML=html;
+    new bootstrap.Modal(document.getElementById('dayModal')).show();
+  });
+});
+var search=document.getElementById('search');
+search.addEventListener('input',function(){
+  var t=this.value.toLowerCase();
+  document.querySelectorAll('#upcomingList [data-search]').forEach(function(a){
+    a.style.display=a.dataset.search.includes(t)?'':'none';
+  });
+});
+</script>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/exchange_rates.php
+++ b/exchange_rates.php
@@ -1,0 +1,26 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$stmt = $pdo->query('SELECT * FROM exchange_rates ORDER BY rate_date DESC');
+$rates = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Kur Bilgisi</h1>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>Tarih</th>
+      <th>USD/TRY</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($rates as $r): ?>
+    <tr>
+      <td><?= htmlspecialchars($r['rate_date']) ?></td>
+      <td><?= number_format($r['usd_try'], 4, ',', '.') ?></td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/exchange_rates_cron.php
+++ b/exchange_rates_cron.php
@@ -1,0 +1,23 @@
+<?php
+require __DIR__.'/includes/db.php';
+
+$xml = @simplexml_load_file('https://www.tcmb.gov.tr/kurlar/today.xml');
+if ($xml) {
+    foreach ($xml->Currency as $currency) {
+        if ((string)$currency['CurrencyCode'] === 'USD') {
+            $rate = str_replace(',', '.', (string)$currency->BanknoteSelling);
+            $exists = $pdo->prepare('SELECT id FROM exchange_rates WHERE rate_date = CURDATE()');
+            $exists->execute();
+            if (!$exists->fetch()) {
+                $stmt = $pdo->prepare("INSERT INTO exchange_rates (rate_date, usd_try) VALUES (CURDATE(), ?)");
+                $stmt->execute([$rate]);
+                echo "Günlük kur kaydedildi: $rate";
+            } else {
+                echo "Kur zaten kayıtlı";
+            }
+            break;
+        }
+    }
+} else {
+    echo "Kur verisi alınamadı";
+}

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/db.php';
+
+session_start();
+
+if (!isset($_SESSION['user_id']) || (time() - ($_SESSION['last_active'] ?? 0) > 1800)) {
+    session_unset();
+    session_destroy();
+    header('Location: /login.php');
+    exit;
+}
+
+$_SESSION['last_active'] = time();
+?>

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,11 @@
+<?php
+$config = include __DIR__ . '/../config/config.php';
+
+$dsn = "mysql:host={$config['db']['host']};dbname={$config['db']['dbname']};charset={$config['db']['charset']}";
+
+try {
+    $pdo = new PDO($dsn, $config['db']['user'], $config['db']['pass']);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    die('Veritabanı bağlantı hatası: ' . $e->getMessage());
+}

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,4 @@
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,23 @@
+<?php
+function getUsdRate(PDO $pdo): float {
+    $stmt = $pdo->query("SELECT usd_try FROM exchange_rates ORDER BY rate_date DESC LIMIT 1");
+    $rate = (float)$stmt->fetchColumn();
+    if($rate){
+        return $rate;
+    }
+    $xml = @simplexml_load_file('https://www.tcmb.gov.tr/kurlar/today.xml');
+    if($xml){
+        foreach($xml->Currency as $cur){
+            if((string)$cur['CurrencyCode']=='USD'){
+                $rate = (float)str_replace(',', '.', (string)$cur->BanknoteSelling);
+                if($rate){
+                    $ins = $pdo->prepare('INSERT INTO exchange_rates(rate_date,usd_try) VALUES (CURDATE(), ?)');
+                    $ins->execute([$rate]);
+                }
+                break;
+            }
+        }
+    }
+    return $rate ?: 0.0;
+}
+?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="UTF-8">
+<title>Takip Sistemi</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<?php
+$settings = [];
+foreach (['logo','logo_header_width','logo_header_height'] as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt->execute([$k]);
+    $settings[$k] = $stmt->fetchColumn() ?: '';
+}
+?>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+ <div class="container-fluid">
+  <a class="navbar-brand" href="/dashboard.php">
+    <?php if ($settings['logo']): ?>
+      <img src="/<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" style="width:<?= (int)$settings['logo_header_width'] ?>px;height:<?= (int)$settings['logo_header_height'] ?>px;object-fit:contain;">
+    <?php else: ?>Takip Sistemi<?php endif; ?>
+  </a>
+  <div class="collapse navbar-collapse">
+   <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item"><a class="nav-link" href="/dashboard.php">Anasayfa</a></li>
+    <li class="nav-item"><a class="nav-link" href="/customers.php">Müşteriler</a></li>
+    <li class="nav-item"><a class="nav-link" href="/services.php">Hizmetler</a></li>
+    <li class="nav-item"><a class="nav-link" href="/products.php">Ürünler</a></li>
+    <li class="nav-item"><a class="nav-link" href="/providers.php">Sağlayıcılar</a></li>
+    <li class="nav-item"><a class="nav-link" href="/users.php">Kullanıcılar</a></li>
+    <li class="nav-item"><a class="nav-link" href="/exchange_rates.php">Kur Bilgisi</a></li>
+    <li class="nav-item"><a class="nav-link" href="/settings.php">Ayarlar</a></li>
+   </ul>
+   <a href="/logout.php" class="btn btn-outline-secondary">Çıkış</a>
+  </div>
+ </div>
+</nav>
+<div class="container mt-4">

--- a/index.php
+++ b/index.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+if (isset($_SESSION['user_id']) && (time() - ($_SESSION['last_active'] ?? 0) < 1800)) {
+    header('Location: /dashboard.php');
+} else {
+    header('Location: /login.php');
+}

--- a/login.php
+++ b/login.php
@@ -1,0 +1,65 @@
+<?php
+require __DIR__ . '/includes/db.php';
+session_start();
+
+if (isset($_SESSION['user_id']) && (time() - ($_SESSION['last_active'] ?? 0) < 1800)) {
+    header('Location: /dashboard.php');
+    exit;
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('SELECT id, password FROM users WHERE email = ?');
+    $stmt->execute([$_POST['email']]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($user && password_verify($_POST['password'], $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['last_active'] = time();
+        header('Location: /dashboard.php');
+        exit;
+    } else {
+        $error = 'Giriş Bilgileri Hatalı';
+    }
+}
+
+$settings = [];
+foreach (['logo','logo_login_width','logo_login_height'] as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt->execute([$k]);
+    $settings[$k] = $stmt->fetchColumn() ?: '';
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="UTF-8">
+<title>Giriş Yap</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap" rel="stylesheet">
+<style>
+body {background: linear-gradient(135deg, #f0f4f8, #d9e2ec); font-family: 'Poppins', sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;}
+.login-box {background: #fff; padding: 40px; border-radius: 16px; box-shadow: 0 10px 40px rgba(0,0,0,0.1); width: 100%; max-width: 400px; text-align: center;}
+.login-logo img {margin-bottom: 20px; width:<?= (int)$settings['logo_login_width'] ?>px; height:<?= (int)$settings['logo_login_height'] ?>px; object-fit:contain;}
+</style>
+</head>
+<body>
+<div class="login-box">
+  <div class="login-logo">
+    <?php if ($settings['logo']): ?><img src="<?= htmlspecialchars($settings['logo']) ?>" alt="Logo"><?php endif; ?>
+  </div>
+  <?php if ($error): ?><div class="alert alert-danger"><?= $error ?></div><?php endif; ?>
+  <form method="post">
+    <div class="mb-3 text-start">
+      <label class="form-label">E-Posta Adresi</label>
+      <input type="email" name="email" class="form-control" required>
+    </div>
+    <div class="mb-3 text-start">
+      <label class="form-label">Şifre</label>
+      <input type="password" name="password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary w-100">Giriş Yap</button>
+  </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: /login.php');
+exit;

--- a/payment_delete.php
+++ b/payment_delete.php
@@ -1,0 +1,11 @@
+<?php
+require __DIR__.'/includes/auth.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT service_id FROM payments WHERE id=?');
+$stmt->execute([$id]);
+$service_id = $stmt->fetchColumn();
+$del = $pdo->prepare('DELETE FROM payments WHERE id=?');
+$del->execute([$id]);
+$redirect = $service_id ? '/service.php?id='.$service_id : '/customers.php';
+header('Location: '.$redirect);
+exit;

--- a/payment_edit.php
+++ b/payment_edit.php
@@ -1,0 +1,44 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM payments WHERE id=?');
+$stmt->execute([$id]);
+$payment = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$payment){
+    header('Location: /services.php');
+    exit;
+}
+$usdRate = getUsdRate($pdo);
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $amount = (float)$_POST['amount'];
+    $currency = $_POST['currency'];
+    $amount_try = $currency==='USD' ? $amount*$usdRate : $amount;
+    $stmt = $pdo->prepare('UPDATE payments SET amount_try=?, amount_orig=?, currency=? WHERE id=?');
+    $stmt->execute([$amount_try,$amount,$currency,$id]);
+    $redirect = $payment['service_id'] ? '/service.php?id='.$payment['service_id'] : '/customers.php';
+    header('Location: '.$redirect);
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Tahsilat Düzenle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Tutar</label>
+    <input type="text" name="amount" class="form-control" value="<?= $payment['amount_orig'] ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Para Birimi</label>
+    <select name="currency" class="form-control">
+      <option value="TRY" <?= $payment['currency']=='TRY'?'selected':'' ?>>TL</option>
+      <option value="USD" <?= $payment['currency']=='USD'?'selected':'' ?>>USD</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="<?= $payment['service_id'] ? '/service.php?id='.$payment['service_id'] : '/customers.php' ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/products.php
+++ b/products.php
@@ -1,0 +1,108 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$action = $_GET['action'] ?? '';
+$id = $_GET['id'] ?? null;
+
+if ($action === 'delete' && $id) {
+    $stmt = $pdo->prepare('DELETE FROM products WHERE id=?');
+    $stmt->execute([$id]);
+    header('Location: /products.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    $unit = $_POST['unit'];
+    $vat_rate = $_POST['vat_rate'];
+    $price = $_POST['price'];
+    $currency = $_POST['currency'];
+    if ($action === 'edit' && $id) {
+        $stmt = $pdo->prepare('UPDATE products SET name=?, unit=?, vat_rate=?, price=?, currency=? WHERE id=?');
+        $stmt->execute([$name, $unit, $vat_rate, $price, $currency, $id]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO products (name, unit, vat_rate, price, currency) VALUES (?, ?, ?, ?, ?)');
+        $stmt->execute([$name, $unit, $vat_rate, $price, $currency]);
+    }
+    header('Location: /products.php');
+    exit;
+}
+
+$edit = null;
+if ($action === 'edit' && $id) {
+    $stmt = $pdo->prepare('SELECT * FROM products WHERE id=?');
+    $stmt->execute([$id]);
+    $edit = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+$products = $pdo->query('SELECT * FROM products ORDER BY id DESC')->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Ürünler</h1>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Ad</th>
+      <th>Birim</th>
+      <th>KDV</th>
+      <th>Fiyat</th>
+      <th>Döviz</th>
+      <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($products as $p): ?>
+    <tr>
+      <td><?= $p['id'] ?></td>
+      <td><?= htmlspecialchars($p['name']) ?></td>
+      <td><?= htmlspecialchars($p['unit']) ?></td>
+      <td><?= $p['vat_rate'] ?></td>
+      <td><?= $p['price'] ?></td>
+      <td><?= htmlspecialchars($p['currency']) ?></td>
+      <td>
+        <a href="/products.php?action=edit&id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="/products.php?action=delete&id=<?= $p['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?')">Sil</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<hr>
+<h2><?= $edit ? 'Ürünü Düzenle' : 'Yeni Ürün' ?></h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ürün Adı</label>
+    <input type="text" name="name" class="form-control" value="<?= $edit['name'] ?? '' ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Birim</label>
+    <select name="unit" class="form-control">
+      <option value="yıl" <?= isset($edit) && $edit['unit']==='yıl' ? 'selected' : '' ?>>Yıl</option>
+      <option value="ay" <?= isset($edit) && $edit['unit']==='ay' ? 'selected' : '' ?>>Ay</option>
+      <option value="adet" <?= isset($edit) && $edit['unit']==='adet' ? 'selected' : '' ?>>Adet</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">KDV</label>
+    <select name="vat_rate" class="form-control">
+      <option value="0" <?= isset($edit) && $edit['vat_rate']==0 ? 'selected' : '' ?>>Yok</option>
+      <option value="10" <?= isset($edit) && $edit['vat_rate']==10 ? 'selected' : '' ?>>%10</option>
+      <option value="20" <?= isset($edit) && $edit['vat_rate']==20 ? 'selected' : '' ?>>%20</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fiyat</label>
+    <input type="text" name="price" class="form-control" value="<?= $edit['price'] ?? '' ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fiyat Türü</label>
+    <select name="currency" class="form-control">
+      <option value="TRY" <?= isset($edit) && $edit['currency']==='TRY' ? 'selected' : '' ?>>TL</option>
+      <option value="USD" <?= isset($edit) && $edit['currency']==='USD' ? 'selected' : '' ?>>USD</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/providers.php
+++ b/providers.php
@@ -1,0 +1,69 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$action = $_GET['action'] ?? '';
+$id = $_GET['id'] ?? null;
+
+if ($action === 'delete' && $id) {
+    $stmt = $pdo->prepare('DELETE FROM providers WHERE id=?');
+    $stmt->execute([$id]);
+    header('Location: /providers.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    if ($action === 'edit' && $id) {
+        $stmt = $pdo->prepare('UPDATE providers SET name=? WHERE id=?');
+        $stmt->execute([$name, $id]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO providers (name) VALUES (?)');
+        $stmt->execute([$name]);
+    }
+    header('Location: /providers.php');
+    exit;
+}
+
+$edit = null;
+if ($action === 'edit' && $id) {
+    $stmt = $pdo->prepare('SELECT * FROM providers WHERE id=?');
+    $stmt->execute([$id]);
+    $edit = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+$providers = $pdo->query('SELECT * FROM providers ORDER BY id DESC')->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Sağlayıcılar</h1>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Ad</th>
+      <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($providers as $p): ?>
+    <tr>
+      <td><?= $p['id'] ?></td>
+      <td><?= htmlspecialchars($p['name']) ?></td>
+      <td>
+        <a href="/providers.php?action=edit&id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="/providers.php?action=delete&id=<?= $p['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?')">Sil</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<hr>
+<h2><?= $edit ? 'Sağlayıcıyı Düzenle' : 'Yeni Sağlayıcı' ?></h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ad</label>
+    <input type="text" name="name" class="form-control" value="<?= $edit['name'] ?? '' ?>" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/service.php
+++ b/service.php
@@ -1,0 +1,91 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT s.*, c.full_name, p.name AS product_name, pr.name AS provider_name FROM services s JOIN customers c ON s.customer_id=c.id LEFT JOIN products p ON s.product_id=p.id LEFT JOIN providers pr ON s.provider_id=pr.id WHERE s.id=?');
+$stmt->execute([$id]);
+$service = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$service){
+    header('Location: /services.php');
+    exit;
+}
+$usdRate = getUsdRate($pdo);
+$priceTl = $service['currency']==='USD' ? $service['price']*$usdRate : $service['price'];
+$vatTl = $priceTl * $service['vat_rate']/100;
+$grand = $priceTl + $vatTl;
+$items = $pdo->prepare('SELECT si.*, pr.name AS provider_name FROM service_items si LEFT JOIN providers pr ON si.provider_id=pr.id WHERE si.service_id=?');
+$items->execute([$service['id']]);
+$items = $items->fetchAll(PDO::FETCH_ASSOC);
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hizmet Detayı</h1>
+<table class="table table-bordered">
+<tr><th>Müşteri</th><td><?= htmlspecialchars($service['full_name']) ?></td></tr>
+<tr><th>Ürün</th><td><?= htmlspecialchars($service['product_name']) ?></td></tr>
+<tr><th>Sağlayıcı</th><td><?= htmlspecialchars($service['provider_name']) ?></td></tr>
+<tr><th>Site</th><td><?= htmlspecialchars($service['site_name']) ?></td></tr>
+<tr><th>Başlangıç</th><td><?= date('d.m.Y', strtotime($service['start_date'])) ?></td></tr>
+<tr><th>Ödeme Tarihi</th><td><?= date('d.m.Y', strtotime($service['due_date'])) ?></td></tr>
+<tr><th>Fiyat</th><td><?= number_format($service['price'],2,',','.') . ' ' . $service['currency'] ?></td></tr>
+<tr><th>Fiyat TL</th><td><?= number_format($priceTl,2,',','.') ?> ₺</td></tr>
+<tr><th>KDV</th><td><?= $service['vat_rate'] ?>%</td></tr>
+<tr><th>Toplam Tutar (TL)</th><td><?= number_format($priceTl,2,',','.') ?> ₺</td></tr>
+<tr><th>KDV Tutarı (TL)</th><td><?= number_format($vatTl,2,',','.') ?> ₺</td></tr>
+<?php if($service['currency']==='USD'): ?>
+<tr><th>Güncel Kur</th><td><?= number_format($usdRate,2,',','.') ?> ₺</td></tr>
+<?php endif; ?>
+<tr><th>Genel Toplam (TL)</th><td><?= number_format($grand,2,',','.') ?> ₺</td></tr>
+<tr><th>Durum</th><td><?= htmlspecialchars($service['status']) ?></td></tr>
+<tr><th>Not</th><td><?= nl2br(htmlspecialchars($service['notes'])) ?></td></tr>
+</table>
+<?php if($items): ?>
+<h2>Hizmet / Ürün Detayı</h2>
+<table class="table table-bordered">
+ <thead>
+  <tr>
+   <th>Ad</th><th>Miktar</th><th>Birim</th><th>Birim Fiyat</th><th>Döviz</th><th>Sağlayıcı</th><th>KDV</th>
+  </tr>
+ </thead>
+ <tbody>
+  <?php foreach($items as $it): ?>
+  <tr>
+   <td><?= htmlspecialchars($it['item_name']) ?></td>
+   <td><?= $it['quantity'] ?></td>
+   <td><?= htmlspecialchars($it['unit']) ?></td>
+   <td><?= number_format($it['unit_price'],2,',','.') ?></td>
+   <td><?= htmlspecialchars($it['currency']) ?></td>
+   <td><?= htmlspecialchars($it['provider_name']) ?></td>
+   <td><?= $it['vat_rate'] ?>%</td>
+  </tr>
+  <?php endforeach; ?>
+ </tbody>
+</table>
+<?php endif; ?>
+<?php
+$payStmt = $pdo->prepare('SELECT * FROM payments WHERE service_id=? ORDER BY id DESC');
+$payStmt->execute([$service['id']]);
+$payments = $payStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2>Tahsilatlar</h2>
+<table class="table table-bordered">
+ <thead>
+  <tr><th>Tutar</th><th>Para Birimi</th><th>Tarih</th><th>İşlem</th></tr>
+ </thead>
+ <tbody>
+  <?php foreach($payments as $p): ?>
+  <tr>
+   <td><?= number_format($p['amount_orig'],2,',','.') ?></td>
+   <td><?= htmlspecialchars($p['currency']) ?></td>
+   <td><?= date('d.m.Y', strtotime($p['created_at'])) ?></td>
+   <td>
+    <a href="/payment_edit.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+    <a href="/payment_delete.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+   </td>
+  </tr>
+  <?php endforeach; ?>
+ </tbody>
+</table>
+<a href="/service_payment.php?service_id=<?= $service['id'] ?>" class="btn btn-primary">Tahsilat Yap</a>
+<a href="/service_edit.php?id=<?= $service['id'] ?>" class="btn btn-warning">Düzenle</a>
+<a href="/service_delete.php?id=<?= $service['id'] ?>" class="btn btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/service_add.php
+++ b/service_add.php
@@ -1,0 +1,181 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+$customers = $pdo->query("SELECT id, full_name FROM customers")->fetchAll(PDO::FETCH_ASSOC);
+$products = $pdo->query("SELECT id, name, price, currency, vat_rate FROM products")->fetchAll(PDO::FETCH_ASSOC);
+$providers = $pdo->query("SELECT id, name FROM providers")->fetchAll(PDO::FETCH_ASSOC);
+$usdRate = getUsdRate($pdo);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $price = (float)$_POST['price'];
+    $start = $_POST['start_date'];
+    $due = $_POST['due_date'] ?: date('Y-m-d', strtotime($start.' +1 year'));
+    $price_try = $price;
+    $duration = (int)((strtotime($due) - strtotime($start)) / 86400);
+    $stmt = $pdo->prepare("INSERT INTO services (customer_id, product_id, provider_id, site_name, service_type, start_date, due_date, duration, unit, price, currency, vat_rate, price_try, status, notes, created_at) VALUES (?, ?, ?, ?, '', ?, ?, ?, 'gün', ?, 'TRY', 0, ?, ?, ?, NOW())");
+    $stmt->execute([
+        $_POST['customer_id'],
+        null,
+        null,
+        $_POST['site_name'],
+        $start,
+        $due,
+        $duration,
+        $price,
+        $price_try,
+        $_POST['status'],
+        $_POST['notes']
+    ]);
+    $serviceId = $pdo->lastInsertId();
+    if(!empty($_POST['item_name'])){
+        $itemStmt = $pdo->prepare('INSERT INTO service_items (service_id,item_name,quantity,unit,unit_price,vat_rate,currency,provider_id) VALUES (?,?,?,?,?,?,?,?)');
+        foreach($_POST['item_name'] as $i => $name){
+            if(trim($name)==='') continue;
+            $itemStmt->execute([
+                $serviceId,
+                $name,
+                (int)($_POST['quantity'][$i] ?? 1),
+                $_POST['unit'][$i] ?? '',
+                (float)($_POST['unit_price'][$i] ?? 0),
+                (float)($_POST['item_vat'][$i] ?? 0),
+                $_POST['item_currency'][$i] ?? 'TRY',
+                $_POST['provider_item'][$i] ?? null
+            ]);
+        }
+    }
+    header('Location: /services.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hizmet Ekle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Müşteri</label>
+    <select name="customer_id" class="form-control" required>
+      <?php foreach ($customers as $c): ?>
+      <option value="<?= $c['id'] ?>"><?= htmlspecialchars($c['full_name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Site / Alan Adı</label>
+    <input type="text" name="site_name" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Başlangıç Tarihi</label>
+    <input type="date" name="start_date" id="start" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ödeme Tarihi</label>
+    <input type="date" name="due_date" id="due" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fiyat</label>
+    <input type="text" name="price" id="price" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Durum</label>
+    <select name="status" class="form-control">
+      <option value="aktif">Aktif</option>
+      <option value="pasif">Pasif</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not</label>
+    <textarea name="notes" class="form-control"></textarea>
+  </div>
+
+  <h3>Hizmet / Ürün Detayı</h3>
+  <table class="table" id="items">
+    <thead>
+      <tr>
+        <th>Hizmet / Ürün</th>
+        <th>Miktar</th>
+        <th>Birim</th>
+        <th>Birim Fiyat</th>
+        <th>Döviz</th>
+        <th>Sağlayıcı</th>
+        <th>KDV</th>
+        <th>Toplam</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <button type="button" class="btn btn-secondary mb-3" id="addRow">Satır Ekle</button>
+
+  <div class="mb-3 text-end">
+    <strong>Toplam Tutar (TL): <span id="total">0</span></strong><br>
+    <strong>KDV Tutarı (TL): <span id="vat_t">0</span></strong><br>
+    <strong>Güncel Kur: <span id="rate"><?= number_format($usdRate,2,',','.') ?></span></strong><br>
+    <strong>Genel Toplam (TL): <span id="grand">0</span></strong>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<script>
+var productOptions = '<?php foreach($products as $p){echo "<option value=\"".$p['name']."\" data-price=\"{$p['price']}\" data-currency=\"{$p['currency']}\" data-vat=\"{$p['vat_rate']}\">".htmlspecialchars($p['name'])."</option>";} ?>';
+var providerOptions = '<?php foreach($providers as $p){echo "<option value=\"{$p['id']}\">".htmlspecialchars($p['name'])."</option>";} ?>';
+function addRow(){
+  var tbody=document.querySelector('#items tbody');
+  var tr=document.createElement('tr');
+  tr.innerHTML='<td><select name="item_name[]" class="form-control prod"><option value="">Seçiniz</option>'+productOptions+'</select></td>'+
+    '<td><input type="number" name="quantity[]" value="1" class="form-control qty"></td>'+
+    '<td><select name="unit[]" class="form-control unit">'+
+      '<option value="adet">Adet</option><option value="ay">Ay</option><option value="yıl">Yıl</option>'+
+    '</select></td>'+
+    '<td><input type="text" name="unit_price[]" class="form-control price"></td>'+
+    '<td><select name="item_currency[]" class="form-control row-currency"><option value="TRY">TRY</option><option value="USD">USD</option></select></td>'+
+    '<td><select name="provider_item[]" class="form-control provider"><option value="">Seçiniz</option>'+providerOptions+'</select></td>'+
+    '<td><select name="item_vat[]" class="form-control vat">'+
+       '<option value="0">%0</option><option value="1">%1</option><option value="10">%10</option><option value="20">%20</option>'+
+    '</select></td>'+
+    '<td class="row-total">0</td>'+
+    '<td><button type="button" class="btn btn-sm btn-danger remove-row">X</button></td>';
+  tbody.appendChild(tr);
+  tr.querySelector('.remove-row').addEventListener('click',function(){tr.remove();updateTotal();});
+  ['input','change'].forEach(function(ev){
+     tr.querySelector('.qty').addEventListener(ev,updateTotal);
+     tr.querySelector('.price').addEventListener(ev,updateTotal);
+     tr.querySelector('.vat').addEventListener(ev,updateTotal);
+     tr.querySelector('.row-currency').addEventListener(ev,updateTotal);
+  });
+  updateTotal();
+}
+function updateTotal(){
+  var rate = <?= $usdRate ? $usdRate : 0 ?>;
+  var totalTl = parseFloat(document.getElementById('price').value)||0;
+  var vatTl = 0;
+  document.querySelectorAll('#items tbody tr').forEach(function(tr){
+    var q = parseFloat(tr.querySelector('.qty').value)||0;
+    var p = parseFloat(tr.querySelector('.price').value)||0;
+    var v = parseFloat(tr.querySelector('.vat').value)||0;
+    var cur = tr.querySelector('.row-currency').value;
+    var lineSub = q*p;
+    var lineVat = lineSub*v/100;
+    var lineTl = cur==='USD' ? (lineSub+lineVat)*rate : (lineSub+lineVat);
+    tr.querySelector('.row-total').innerText=lineTl.toFixed(2);
+    totalTl += cur==='USD' ? lineSub*rate : lineSub;
+    vatTl += cur==='USD' ? lineVat*rate : lineVat;
+  });
+  document.getElementById('total').innerText=totalTl.toFixed(2);
+  document.getElementById('vat_t').innerText=vatTl.toFixed(2);
+  document.getElementById('grand').innerText=(totalTl+vatTl).toFixed(2);
+}
+document.getElementById('price').addEventListener('input',updateTotal);
+document.getElementById('start').addEventListener('change',function(){
+  if(!document.getElementById('due').value){
+    var start=new Date(this.value);
+    if(start.toString()!=='Invalid Date'){
+      start.setFullYear(start.getFullYear()+1);
+      document.getElementById('due').value=start.toISOString().slice(0,10);
+    }
+  }
+});
+document.getElementById('addRow').addEventListener('click',addRow);
+addRow();
+updateTotal();
+</script>
+<div class="mb-5"></div>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/service_delete.php
+++ b/service_delete.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__.'/includes/auth.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('DELETE FROM services WHERE id=?');
+$stmt->execute([$id]);
+header('Location: /services.php');
+exit;

--- a/service_edit.php
+++ b/service_edit.php
@@ -1,0 +1,136 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM services WHERE id=?');
+$stmt->execute([$id]);
+$service = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$service){
+    header('Location: /services.php');
+    exit;
+}
+
+$customers = $pdo->query("SELECT id, full_name FROM customers")->fetchAll(PDO::FETCH_ASSOC);
+$products = $pdo->query("SELECT id, name, price, currency, vat_rate FROM products")->fetchAll(PDO::FETCH_ASSOC);
+$providers = $pdo->query("SELECT id, name FROM providers")->fetchAll(PDO::FETCH_ASSOC);
+$usdRate = getUsdRate($pdo);
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $price = (float)$_POST['price'];
+    $currency = $_POST['currency'];
+    $vat_rate = (float)$_POST['vat_rate'];
+    $start = $_POST['start_date'];
+    $due = $_POST['due_date'] ?: date('Y-m-d', strtotime($start.' +1 year'));
+    $price_try = $currency==='USD' ? $price*$usdRate : $price;
+    $duration = (int)((strtotime($due)-strtotime($start))/86400);
+    $stmt = $pdo->prepare('UPDATE services SET customer_id=?, product_id=?, provider_id=?, site_name=?, start_date=?, due_date=?, duration=?, price=?, currency=?, vat_rate=?, price_try=?, status=?, notes=? WHERE id=?');
+    $stmt->execute([
+        $_POST['customer_id'],
+        $_POST['product_id'],
+        $_POST['provider_id'],
+        $_POST['site_name'],
+        $start,
+        $due,
+        $duration,
+        $price,
+        $currency,
+        $vat_rate,
+        $price_try,
+        $_POST['status'],
+        $_POST['notes'],
+        $id
+    ]);
+    header('Location: /service.php?id='.$id);
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hizmet Düzenle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Müşteri</label>
+    <select name="customer_id" class="form-control" required>
+      <?php foreach($customers as $c): ?>
+      <option value="<?= $c['id'] ?>" <?= $c['id']==$service['customer_id']?'selected':'' ?>><?= htmlspecialchars($c['full_name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ürün</label>
+    <select name="product_id" id="product" class="form-control" required>
+      <option value="">Seçiniz</option>
+      <?php foreach($products as $p): ?>
+      <option value="<?= $p['id'] ?>" data-price="<?= $p['price'] ?>" data-currency="<?= $p['currency'] ?>" data-vat="<?= $p['vat_rate'] ?>" <?= $p['id']==$service['product_id']?'selected':'' ?>><?= htmlspecialchars($p['name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Sağlayıcı</label>
+    <select name="provider_id" class="form-control">
+      <option value="">Seçiniz</option>
+      <?php foreach($providers as $p): ?>
+      <option value="<?= $p['id'] ?>" <?= $p['id']==$service['provider_id']?'selected':'' ?>><?= htmlspecialchars($p['name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Site / Alan Adı</label>
+    <input type="text" name="site_name" class="form-control" value="<?= htmlspecialchars($service['site_name']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Başlangıç Tarihi</label>
+    <input type="date" name="start_date" id="start" class="form-control" value="<?= $service['start_date'] ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ödeme Tarihi</label>
+    <input type="date" name="due_date" id="due" class="form-control" value="<?= $service['due_date'] ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fiyat</label>
+    <input type="text" name="price" id="price" class="form-control" value="<?= $service['price'] ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Döviz</label>
+    <select name="currency" id="currency" class="form-control">
+      <option value="TRY" <?= $service['currency']=='TRY'?'selected':'' ?>>TRY</option>
+      <option value="USD" <?= $service['currency']=='USD'?'selected':'' ?>>USD</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">KDV Oranı</label>
+    <select name="vat_rate" id="vat" class="form-control">
+      <option value="0" <?= $service['vat_rate']==0?'selected':'' ?>>Yok</option>
+      <option value="10" <?= $service['vat_rate']==10?'selected':'' ?>>%10</option>
+      <option value="20" <?= $service['vat_rate']==20?'selected':'' ?>>%20</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Durum</label>
+    <select name="status" class="form-control">
+      <option value="aktif" <?= $service['status']=='aktif'?'selected':'' ?>>Aktif</option>
+      <option value="pasif" <?= $service['status']=='pasif'?'selected':'' ?>>Pasif</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not</label>
+    <textarea name="notes" class="form-control"><?= htmlspecialchars($service['notes']) ?></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="/services.php" class="btn btn-secondary">İptal</a>
+</form>
+<script>
+function updateFromProduct(){
+  var sel=document.getElementById('product');
+  var opt=sel.options[sel.selectedIndex];
+  if(opt && opt.dataset.price){
+    document.getElementById('price').value=opt.dataset.price;
+    document.getElementById('currency').value=opt.dataset.currency;
+    document.getElementById('vat').value=opt.dataset.vat;
+  }
+}
+
+document.getElementById('product').addEventListener('change',updateFromProduct);
+</script>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/service_payment.php
+++ b/service_payment.php
@@ -1,0 +1,130 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$service_id = isset($_GET['service_id']) ? (int)$_GET['service_id'] : 0;
+$stmt = $pdo->prepare('SELECT s.*, c.full_name FROM services s JOIN customers c ON s.customer_id=c.id WHERE s.id=?');
+$stmt->execute([$service_id]);
+$service = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$service){
+    header('Location: /services.php');
+    exit;
+}
+$customer_id = $service['customer_id'];
+
+$usdRate = getUsdRate($pdo);
+
+// mevcut borcu hesapla
+$paidStmt = $pdo->prepare('SELECT SUM(amount_try) FROM payments WHERE service_id=?');
+$paidStmt->execute([$service_id]);
+$paid_try = (float)$paidStmt->fetchColumn();
+$service_total_try = $service['price_try'] * (1 + $service['vat_rate']/100);
+$remain_try = $service_total_try - $paid_try;
+if ($remain_try < 0) $remain_try = 0;
+$remain_cur = $service['currency'] === 'USD' ? ($remain_try / ($usdRate ?: 1)) : $remain_try;
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $amount = (float)$_POST['amount'];
+    $currency = $_POST['currency'];
+    $amount_try = $currency==='USD' ? $amount * $usdRate : $amount;
+    $stmt = $pdo->prepare('INSERT INTO payments (customer_id, service_id, amount_try, amount_orig, currency) VALUES (?,?,?,?,?)');
+    $stmt->execute([$customer_id, $service_id, $amount_try, $amount, $currency]);
+
+    if(isset($_POST['renew'])){
+        $years = (int)$_POST['years'];
+        $renew_price = (float)$_POST['renew_price'];
+        $renew_currency = $_POST['renew_currency'];
+        $renew_vat_rate = (float)$_POST['renew_vat_rate'];
+        $renew_apply_vat = isset($_POST['renew_apply_vat']);
+        $price = $renew_price * $years;
+        if($renew_apply_vat){
+            $price *= (1 + $renew_vat_rate/100);
+        }
+        $price_try = $renew_currency==='USD' ? $price * $usdRate : $price;
+        $start = $service['due_date'];
+        $due = date('Y-m-d', strtotime($start.' +'.$years.' year'));
+        $duration = (int)((strtotime($due)-strtotime($start))/86400);
+        $stmt = $pdo->prepare("INSERT INTO services (customer_id, product_id, provider_id, site_name, service_type, start_date, due_date, duration, unit, price, currency, vat_rate, price_try, status, notes, created_at) VALUES (?,?,?,?,?,?,?,?, 'gün', ?, ?, ?, ?, ?, ?, NOW())");
+        $stmt->execute([$customer_id,$service['product_id'],$service['provider_id'],$service['site_name'],$service['service_type'],$start,$due,$duration,$renew_price*$years,$renew_currency,$renew_vat_rate,$price_try,$service['status'],$service['notes']]);
+    }
+
+    header('Location: /customer.php?id='.$customer_id);
+    exit;
+}
+
+$total_default = $service['price'];
+$default_years = 1;
+$default_apply_vat = true;
+$calc_total = function($yrs,$vat) use($service){
+    $price = $service['price'] * $yrs;
+    if($vat){
+        $price *= (1 + $service['vat_rate']/100);
+    }
+    return $price;
+};
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hizmet Tahsilatı - <?= htmlspecialchars($service['full_name']) ?></h1>
+<p>Hizmet: <?= htmlspecialchars($service['service_type']) ?> - <?= htmlspecialchars($service['site_name']) ?></p>
+<p><strong>Toplam Borç:</strong> <?= number_format($remain_cur,2,',','.') ?> <?= $service['currency'] ?> (<?= number_format($remain_try,2,',','.') ?> TL)</p>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Tutar</label>
+    <input type="text" name="amount" class="form-control" value="<?= number_format($remain_cur,2,'.','') ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Para Birimi</label>
+    <select name="currency" class="form-control">
+      <option value="TRY" <?= $service['currency']=='TRY'?'selected':'' ?>>TL</option>
+      <option value="USD" <?= $service['currency']=='USD'?'selected':'' ?>>USD</option>
+    </select>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="renew" name="renew">
+    <label class="form-check-label" for="renew">Tahsilattan sonra hizmeti uzat</label>
+  </div>
+  <div id="renewFields" style="display:none;">
+    <div class="mb-3">
+      <label class="form-label">Kaç Yıl Uzatılsın</label>
+      <select name="years" class="form-control">
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Fiyat</label>
+      <input type="text" name="renew_price" id="renew_price" value="<?= $service['price'] ?>" class="form-control">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Para Birimi</label>
+      <select name="renew_currency" id="renew_currency" class="form-control">
+        <option value="TRY" <?= $service['currency']=='TRY'?'selected':'' ?>>TL</option>
+        <option value="USD" <?= $service['currency']=='USD'?'selected':'' ?>>USD</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">KDV Oranı</label>
+      <select name="renew_vat_rate" id="renew_vat_rate" class="form-control">
+        <option value="0" <?= $service['vat_rate']==0?'selected':'' ?>>Yok</option>
+        <option value="10" <?= $service['vat_rate']==10?'selected':'' ?>>%10</option>
+        <option value="20" <?= $service['vat_rate']==20?'selected':'' ?>>%20</option>
+      </select>
+    </div>
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" name="renew_apply_vat" id="renew_vat" <?= $service['vat_rate']>0?'checked':'' ?>>
+      <label class="form-check-label" for="renew_vat">KDV Eklensin</label>
+    </div>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="/customer.php?id=<?= $customer_id ?>" class="btn btn-secondary">İptal</a>
+</form>
+<script>
+ document.getElementById('renew').addEventListener('change',function(){
+   document.getElementById('renewFields').style.display=this.checked?'block':'none';
+ });
+</script>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/services.php
+++ b/services.php
@@ -1,0 +1,59 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+include __DIR__.'/includes/header.php';
+
+$stmt = $pdo->query("SELECT s.*, c.full_name, p.name AS product_name, pr.name AS provider_name FROM services s JOIN customers c ON s.customer_id=c.id LEFT JOIN products p ON s.product_id=p.id LEFT JOIN providers pr ON s.provider_id=pr.id ORDER BY s.id DESC");
+$services = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$usdRate = getUsdRate($pdo);
+?>
+<h1>Hizmetler</h1>
+<a href="/service_add.php" class="btn btn-primary mb-3">Hizmet Ekle</a>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+       <th>ID</th>
+       <th>Müşteri</th>
+       <th>Ürün</th>
+       <th>Sağlayıcı</th>
+       <th>Site</th>
+       <th>Başlangıç</th>
+       <th>Ödeme Tarihi</th>
+       <th>Fiyat</th>
+       <th>Fiyat TL</th>
+       <th>KDV</th>
+       <th>Genel Toplam</th>
+       <th>Durum</th>
+       <th>Not</th>
+       <th>Oluşturma</th>
+       <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($services as $s): ?>
+    <tr>
+      <td><?= $s['id'] ?></td>
+      <td><?= htmlspecialchars($s['full_name']) ?></td>
+      <td><?= htmlspecialchars($s['product_name']) ?></td>
+      <td><?= htmlspecialchars($s['provider_name']) ?></td>
+      <td><?= htmlspecialchars($s['site_name']) ?></td>
+      <td><?= date('d.m.Y', strtotime($s['start_date'])) ?></td>
+      <td><?= date('d.m.Y', strtotime($s['due_date'])) ?></td>
+      <td><?= number_format($s['price'],2,',','.') . ' ' . $s['currency'] ?></td>
+      <td><?= number_format($s['price_try'],2,',','.') ?> ₺</td>
+      <td><?= $s['vat_rate'] ?>%</td>
+      <td><?= number_format($s['price_try'] * (1 + $s['vat_rate']/100), 2, ',', '.') ?> ₺</td>
+      <td><?= htmlspecialchars($s['status']) ?></td>
+      <td><?= htmlspecialchars($s['notes']) ?></td>
+      <td><?= date('d.m.Y', strtotime($s['created_at'])) ?></td>
+      <td>
+        <a href="/service.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-info">Detay</a>
+        <a href="/service_payment.php?service_id=<?= $s['id'] ?>" class="btn btn-sm btn-primary">Tahsilat</a>
+        <a href="/service_edit.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="/service_delete.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,64 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$settings = [];
+$keys = ['logo','logo_login_width','logo_login_height','logo_header_width','logo_header_height'];
+foreach ($keys as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt->execute([$k]);
+    $settings[$k] = $stmt->fetchColumn() ?: '';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!empty($_FILES['logo']['tmp_name'])) {
+        $dir = 'uploads';
+        if (!is_dir($dir)) mkdir($dir, 0777, true);
+        $path = $dir . '/' . basename($_FILES['logo']['name']);
+        move_uploaded_file($_FILES['logo']['tmp_name'], $path);
+        $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES ('logo', ?)");
+        $stmt->execute([$path]);
+        $settings['logo'] = $path;
+    }
+    foreach (['logo_login_width','logo_login_height','logo_header_width','logo_header_height'] as $k) {
+        if (isset($_POST[$k])) {
+            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES (?, ?)");
+            $stmt->execute([$k, $_POST[$k]]);
+            $settings[$k] = $_POST[$k];
+        }
+    }
+}
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Logo Ayarları</h1>
+<form method="post" enctype="multipart/form-data">
+  <div class="mb-3">
+    <label class="form-label">Logo Yükle</label>
+    <input type="file" name="logo" class="form-control">
+  </div>
+  <?php if ($settings['logo']): ?>
+  <div class="mb-3">
+    <img src="/<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" style="max-width:200px;">
+  </div>
+  <?php endif; ?>
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Login Logo Genişlik</label>
+      <input type="number" name="logo_login_width" class="form-control" value="<?= htmlspecialchars($settings['logo_login_width']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Login Logo Yükseklik</label>
+      <input type="number" name="logo_login_height" class="form-control" value="<?= htmlspecialchars($settings['logo_login_height']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Header Logo Genişlik</label>
+      <input type="number" name="logo_header_width" class="form-control" value="<?= htmlspecialchars($settings['logo_header_width']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Header Logo Yükseklik</label>
+      <input type="number" name="logo_header_height" class="form-control" value="<?= htmlspecialchars($settings['logo_header_height']) ?>">
+    </div>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,105 @@
+CREATE TABLE customers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  full_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255),
+  phone VARCHAR(50),
+  company VARCHAR(255),
+  address TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE products (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255),
+  unit VARCHAR(20),
+  vat_rate DECIMAL(5,2),
+  price DECIMAL(10,2),
+  currency VARCHAR(10),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE providers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE services (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  customer_id INT NOT NULL,
+  product_id INT,
+  provider_id INT,
+  site_name VARCHAR(255),
+  service_type VARCHAR(50),
+  start_date DATE,
+  due_date DATE,
+  duration INT,
+  unit VARCHAR(10),
+  price DECIMAL(10,2),
+  currency VARCHAR(10),
+  vat_rate DECIMAL(5,2),
+  price_try DECIMAL(10,2),
+  status VARCHAR(20),
+  notes TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id),
+  FOREIGN KEY (provider_id) REFERENCES providers(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE service_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  service_id INT NOT NULL,
+  item_name VARCHAR(255),
+  quantity INT DEFAULT 1,
+  unit VARCHAR(20),
+  unit_price DECIMAL(10,2),
+  vat_rate DECIMAL(5,2),
+  currency VARCHAR(10),
+  provider_id INT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE,
+  FOREIGN KEY (provider_id) REFERENCES providers(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE exchange_rates (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  rate_date DATE,
+  usd_try DECIMAL(10,4),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE payments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  customer_id INT NOT NULL,
+  service_id INT,
+  amount_try DECIMAL(10,2),
+  amount_orig DECIMAL(10,2),
+  currency VARCHAR(10),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE,
+  FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(100) UNIQUE,
+  password VARCHAR(255),
+  role ENUM('admin','user') DEFAULT 'admin',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE settings (
+  `key` VARCHAR(50) PRIMARY KEY,
+  value TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO users (email, password, role) VALUES
+('info@precadmedya.com.tr', '$2y$12$g0QsFECHVjIwr2WhxPLLV.i/wskHA2S0VuZY0bowUph3KdXmaZ3MS', 'admin');
+
+INSERT INTO settings (`key`, value) VALUES
+('logo', ''),
+('logo_login_width','140'),
+('logo_login_height','40'),
+('logo_header_width','120'),
+('logo_header_height','40');

--- a/users.php
+++ b/users.php
@@ -1,0 +1,90 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$action = $_GET['action'] ?? '';
+$id = $_GET['id'] ?? null;
+
+if ($action === 'delete' && $id) {
+    $stmt = $pdo->prepare('DELETE FROM users WHERE id=?');
+    $stmt->execute([$id]);
+    header('Location: /users.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'];
+    $role = $_POST['role'];
+    if ($action === 'edit' && $id) {
+        if (!empty($_POST['password'])) {
+            $pass = password_hash($_POST['password'], PASSWORD_BCRYPT);
+            $stmt = $pdo->prepare('UPDATE users SET email=?, password=?, role=? WHERE id=?');
+            $stmt->execute([$email, $pass, $role, $id]);
+        } else {
+            $stmt = $pdo->prepare('UPDATE users SET email=?, role=? WHERE id=?');
+            $stmt->execute([$email, $role, $id]);
+        }
+    } else {
+        $pass = password_hash($_POST['password'], PASSWORD_BCRYPT);
+        $stmt = $pdo->prepare('INSERT INTO users (email, password, role) VALUES (?, ?, ?)');
+        $stmt->execute([$email, $pass, $role]);
+    }
+    header('Location: /users.php');
+    exit;
+}
+
+$editUser = null;
+if ($action === 'edit' && $id) {
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE id=?');
+    $stmt->execute([$id]);
+    $editUser = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+$users = $pdo->query('SELECT * FROM users ORDER BY id DESC')->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Kullanıcılar</h1>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>E-Posta</th>
+      <th>Rol</th>
+      <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+    <?php foreach ($users as $u): ?>
+    <tr>
+      <td><?= $u['id'] ?></td>
+      <td><?= htmlspecialchars($u['email']) ?></td>
+      <td><?= $u['role'] ?></td>
+      <td>
+        <a href="/users.php?action=edit&id=<?= $u['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="/users.php?action=delete&id=<?= $u['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?')">Sil</a>
+      </td>
+    </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>
+<hr>
+<h2><?= $editUser ? 'Kullanıcı Düzenle' : 'Yeni Kullanıcı' ?></h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">E-Posta</label>
+    <input type="email" name="email" class="form-control" value="<?= $editUser['email'] ?? '' ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Şifre<?= $editUser ? ' (değiştirmek için doldur)' : '' ?></label>
+    <input type="password" name="password" class="form-control" <?= $editUser ? '' : 'required' ?>>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Rol</label>
+    <select name="role" class="form-control">
+      <option value="admin" <?= isset($editUser) && $editUser['role']==='admin' ? 'selected' : '' ?>>Admin</option>
+      <option value="user" <?= isset($editUser) && $editUser['role']==='user' ? 'selected' : '' ?>>User</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- allow adding invoice-like line items when creating a service
- store new service_items records and display them on the service detail page
- document the service_items table and update service_add description

## Testing
- `php -v | head -n 1`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687ecc6713948333a3c2bf44a8c3072c