### PR TITLE
Fix email sender defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,109 @@
-# takip_sistemi
+# Takip Sistemi
+
+Bu proje, domain ve hosting hizmetlerini takip etmek için basit bir PHP panelidir.
+
+## Kurulum
+
+1. `sql/schema.sql` dosyasındaki tabloları MySQL veritabanınıza aktarın.
+2. `config/config.php` dosyasında yer alan veritabanı ve SMTP bilgilerini gerekirse güncelleyin.
+3. `uploads/` klasörünün yazılabilir olduğundan emin olun.
+4. Depo kök dizinini web sunucunuzun kök dizini olarak ayarlayın.
+5. `exchange_rates_cron.php` dosyasını her gün çalışacak şekilde cron'a ekleyerek döviz kurlarının otomatik güncellenmesini sağlayın.
+   Örnek cron satırı:
+
+   ```
+   0 9 * * * php /path/to/exchange_rates_cron.php >/dev/null 2>&1
+   ```
+
+6. Tüm ayarlar yapıldıktan sonra `login.php` sayfasından belirtilen varsayılan bilgilerle sisteme giriş yapabilirsiniz.
+
+İlk giriş için veritabanına varsayılan bir kullanıcı eklenmiştir:
+
+- E‑posta: `info@precadmedya.com.tr`
+- Şifre: `123456`
+
+## Sayfalar
+
+- `/login.php` – Oturum açma ekranı
+- `/dashboard.php` – Anasayfa, iki sütunlu takvim ve yaklaşan hizmet listesi
+- `/customers.php` – Müşteri listesi
+ - `/customer_payment.php` – Müşteri tahsilatı (isteğe bağlı hizmet seçilebilir)
+- `/customer.php` – Müşterinin detaylı sayfası, geçmiş ödemeler ve yaklaşan borçlar
+- `/customer_statement.php` – Müşteri ekstresi (PDF indirme)
+ - `/customer_add.php` – Müşteri ekleme formu
+ - `/customer_edit.php` – Müşteri düzenleme
+ - `/customer_delete.php` – Müşteri silme
+ - `/services.php` – Hizmet listesi
+ - `/service_payment.php` – Hizmet tahsilatı ve yenileme
+   (mevcut borcu görüntüler ve ödeme sonrası uzatma seçeneği sunar)
+ - `/service_add.php` – Hizmet ekleme formu. Ürün satırında seçim yapıldığında fiyat, döviz ve KDV otomatik dolar.
+  Satırlarda "Açıklama" alanı bulunur ve "+ Özel Ürün" seçildiğinde bilgiler doğrudan satırdan yazılarak kaydedilebilir. İstenirse bu ürünler otomatik olarak ürünler listesine eklenir. İsteğe bağlı olarak belirli günlerde hatırlatma e-postası gönderilmesi için seçenekler vardır.
+ - `/service_edit.php` – Hizmet düzenleme
+ - `/service_delete.php` – Hizmet silme
+- `/service.php` – Hizmet detayları, ek kalem tablosu ve tahsilat geçmişi
+ - `/send_reminder.php?service_id=X` – Manuel hatırlatma maili gönderir (konu ve içerik düzenlenebilir)
+- `/payment_edit.php` – Tahsilat düzenleme
+- `/payment_delete.php` – Tahsilat silme
+- `/products.php` – Ürün yönetimi
+- `/providers.php` – Sağlayıcı yönetimi (borç tutarlarını gösterir, detay sayfasından satın alımlar listelenebilir)
+- `/provider.php?id=X` – Tedarikçi detay sayfası ve yeni satın alım girişi
+- `/purchase_edit.php?id=X` – Satın alınan ürünü düzenleme
+- `/purchase_delete.php?id=X` – Satın alınan ürünü silme
+ - `/provider_payment.php?provider_id=X` – Tedarikçiye ödeme kaydetme
+ - `/provider_payment_edit.php?id=X` – Tedarikçi ödemesini düzenleme
+ - `/provider_payment_delete.php?id=X` – Tedarikçi ödemesini silme
+ - `/purchase_add.php` – Sağlayıcı seçerek ürün satın alma formu
+ - `/users.php` – Kullanıcı yönetimi
+ - `/settings.php` – Logo ayarları
+ - `/email_settings.php` – SMTP ve e-posta logo ayarları
+- `/update_rates.php` – TCMB kurunu çekip hizmet toplamlarını güncelleme (header'daki "Kur Güncelle" butonuyla erişilir)
+- `/exchange_rates_cron.php` – Günlük kur çekme işlemi
+- `/reminder_cron.php` – Hatırlatma maillerini otomatik gönderir
+- `/exchange_rates.php` – Kur geçmişi listesi
+
+`exchange_rates_cron.php` dosyası her gün çalıştırılarak TCMB'den USD kurunun
+güncel değerini `exchange_rates` tablosuna kaydeder. Cron örneği:
+
+```
+0 9 * * * php /path/to/exchange_rates_cron.php >/dev/null 2>&1
+```
+
+Hatırlatma maillerini göndermek için benzer şekilde `reminder_cron.php` dosyası günlük çalıştırılabilir:
+
+```
+0 8 * * * php /path/to/reminder_cron.php >/dev/null 2>&1
+```
+Hatırlatmalar ilgili müşterinin e-posta adresine "Precad Medya" gönderen adıyla
+"Domain süreniz dolmak üzere" konu başlığıyla gönderilir.
+
+SMTP ayarları `email_settings.php` sayfasından değiştirilebilir. Buradaki bilgiler
+`config/config.php` dosyasındaki varsayılan ayarların üzerine yazılır ve mail
+gönderiminde kullanılır. Bu ekranda test e-postası gönderebileceğiniz bir
+alan bulunur; gönderim başarısız olursa hata mesajı görüntülenir. Mail sistemi,
+Yandex SMTP sunucusuyla uyumlu olacak şekilde güncellenmiş basit bir PHPMailer
+sınıfı kullanır ve bağlantı hatalarını ayrıntılı olarak bildirir.
+Gönderen adı veya e‑posta adresi bu sayfada boş bırakılırsa sistem otomatik
+olarak "Precad Medya" / `info@precadmedya.com.tr` değerlerini kullanır.
+Konu alanı boş girilirse "Ödeme Hatırlatma" metni atanır ve e‑postalar bu
+başlıkla gönderilir.
+
+Müşteri listesi sayfasında her müşterinin TL cinsinden bakiyesi görüntülenir. USD olarak kaydedilmiş hizmet bedelleri, sistemdeki en güncel kura göre TL'ye dönüştürülerek hesaplanır. Tahsilatlar hem müşteri hem de hizmet bazında kaydedilir ve bakiye bu ödemeler düşülerek hesaplanır.
+
+Tüm arayüz Türkçe olup Bootstrap 5 ile mobil uyumlu tasarlanmıştır. Sayfalara erişmek için oturum açmak gereklidir.
+Logo yükleme sayfasında giriş ve üst menüde kullanılacak logonun boyutları ayarlanabilir. Aynı ekranda alt bilgi metni ve footer logosu da düzenlenebilir.
+
+Veritabanında `payments` tablosu tahsilat kayıtlarını tutar ve `exchange_rates` tablosundaki güncel dolar kuru kullanılarak USD tahsilatları otomatik TL'ye çevrilir.
+Her hizmet için ek kalemlerin saklandığı `service_items` tablosu da bulunmaktadır. Bu tabloda her kalemin döviz türü, sağlayıcı bilgisi ve açıklaması saklanır.
+Hizmet kayıtlarında hem orijinal para birimi hem de TL karşılığı saklanır ve ödeme tarihi alanı bulunur.
+Tedarikçilerden yapılan alımlar `provider_purchases` tablosuna kaydedilir ve toplam tutarlar sağlayıcı listesinde görüntülenir.
+Sağlayıcı ödemeleri `provider_payments` tablosunda tutulur; ödemeler eklenebilir, düzenlenebilir ve silinebilir.
+Alım kayıtları düzenlenip silinebilir.
+Dashboard sayfasındaki takvimde müşteriler ve sağlayıcılar için ayrı sekmeler bulunur. Sağlayıcı takvimi ödeme tarihlerini gösterir ve son 30 gün içindeki tutar kart olarak listelenir.
+
+Sağlayıcı eklerken web sitesi de kaydedilebilir. Sağlayıcı detay sayfasında ürün adı, miktar, birim, birim fiyat, döviz ve KDV oranı girilerek satın alımlar eklenir. Girilen değerler güncel USD kuru kullanılarak TL'ye çevrilir ve satırın altında birim fiyat, KDV tutarı ve toplam tutar olarak gösterilir. Sağlayıcı listesi her sağlayıcı için biriken toplam ödemeyi TL cinsinden gösterir.
+
+`update_rates.php` sayfasıyla TCMB'den güncel USD kuru çekilerek tüm hizmet toplamları yeniden hesaplanabilir. Güncel kur bilgisi menüde gösterilir ve yanındaki renkli butonla güncellenebilir. Hizmet detayı sayfasında kalan gün bir rozet olarak görünür ve alt kısımda birim fiyat, KDV tutarı ve genel toplam TL olarak listelenir. Müşteri ekstresi PDF formatında logo ile birlikte indirilebilir.
+
+Dashboard sayfasında aylık görünümlü bir takvim ile yaklaşan hizmet bitişleri aynı sayfada iki sütun olarak gösterilir. Takvimde hizmet tarihi olan günler renkli çubuklarla işaretlenir ve tıklandığında o güne ait hizmetler modal pencerede açılır. Sağdaki listede en yakın on hizmet bitişi arama kutusuyla filtrelenebilir. Alt bölümde en çok satan ve son eklenen hizmetler yer alır.
+
+Gönderilen hatırlatma e-postaları `email_logs` tablosunda saklanır.

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,19 @@
+<?php
+return [
+    'db' => [
+        'host' => getenv('DB_HOST') ?: 'localhost',
+        'dbname' => getenv('DB_NAME') ?: 'precadme_takip',
+        'user' => getenv('DB_USER') ?: 'precadme_takip',
+        'pass' => getenv('DB_PASS') ?: 'Kolega3452323',
+        'charset' => 'utf8mb4'
+    ],
+    'smtp' => [
+        'host' => getenv('SMTP_HOST') ?: 'smtp.yandex.com.tr',
+        'port' => getenv('SMTP_PORT') ?: 465,
+        'encryption' => getenv('SMTP_ENCRYPTION') ?: 'ssl',
+        'username' => getenv('SMTP_USER') ?: 'info@precadmedya.com.tr',
+        'password' => getenv('SMTP_PASS') ?: 'Precadmedya34523',
+        'from_name' => getenv('SMTP_FROM_NAME') ?: 'Precad Medya',
+        'from_email' => getenv('SMTP_FROM_EMAIL') ?: 'info@precadmedya.com.tr'
+    ]
+];

--- a/customer.php
+++ b/customer.php
@@ -1,0 +1,124 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
+$stmt->execute([$id]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$customer){
+    header('Location: customers.php');
+    exit;
+}
+
+$svcStmt = $pdo->prepare('SELECT s.*, p.name AS product_name, pr.name AS provider_name,
+    IFNULL((SELECT SUM(amount_try) FROM payments WHERE service_id=s.id),0) AS paid_try
+    FROM services s
+    LEFT JOIN products p ON s.product_id=p.id
+    LEFT JOIN providers pr ON s.provider_id=pr.id
+    WHERE s.customer_id=? ORDER BY s.id DESC');
+$svcStmt->execute([$id]);
+$services = $svcStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$payStmt = $pdo->prepare('SELECT p.*, s.site_name FROM payments p
+    LEFT JOIN services s ON p.service_id=s.id
+    WHERE p.customer_id=? ORDER BY p.created_at DESC');
+$payStmt->execute([$id]);
+$payments = $payStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$usdRate = getUsdRate($pdo);
+$totalDebt = 0;
+$upcoming = [];
+foreach($services as &$s){
+    $s['total_try'] = $s['price_try'] * (1 + $s['vat_rate']/100);
+    $s['remaining'] = $s['total_try'] - $s['paid_try'];
+    if($s['remaining'] > 0){
+        $totalDebt += $s['remaining'];
+        if(strtotime($s['due_date']) <= strtotime('+30 days')){
+            $upcoming[] = $s;
+        }
+    }
+}
+unset($s);
+
+include __DIR__.'/includes/header.php';
+?>
+<h1><?= htmlspecialchars($customer['full_name']) ?></h1>
+<p>E-Posta: <?= htmlspecialchars($customer['email']) ?></p>
+<p>Telefon: <?= htmlspecialchars($customer['phone']) ?></p>
+<p>Şirket: <?= htmlspecialchars($customer['company']) ?></p>
+<p>Adres: <?= nl2br(htmlspecialchars($customer['address'])) ?></p>
+<a href="customer_payment.php?customer_id=<?= $id ?>" class="btn btn-success mb-3">Tahsilat Yap</a>
+<a href="customer_edit.php?id=<?= $id ?>" class="btn btn-warning mb-3">Düzenle</a>
+<a href="customer_delete.php?id=<?= $id ?>" class="btn btn-danger mb-3" onclick="return confirm('Silinsin mi?');">Sil</a>
+<a href="customer_statement.php?id=<?= $id ?>" class="btn btn-secondary mb-3">Ekstre İndir</a>
+<div class="row mb-4">
+ <div class="col-md-6">
+  <div class="card text-bg-light mb-3">
+   <div class="card-body">
+    <h5 class="card-title">Toplam Borç</h5>
+    <p class="card-text fw-bold"><?= number_format($totalDebt,2,',','.') ?> ₺</p>
+   </div>
+  </div>
+ </div>
+ <div class="col-md-6">
+  <div class="card text-bg-light mb-3">
+   <div class="card-body">
+    <h5 class="card-title">Yaklaşan Ödemeler (30 gün)</h5>
+    <?php if($upcoming): ?>
+    <ul class="mb-0">
+     <?php foreach($upcoming as $u): ?>
+     <li><?= htmlspecialchars($u['site_name']) ?> - <?= date('d.m.Y', strtotime($u['due_date'])) ?> - <?= number_format($u['remaining'],2,',','.') ?> ₺</li>
+     <?php endforeach; ?>
+    </ul>
+    <?php else: ?>
+    <p class="mb-0">Yaklaşan ödeme yok</p>
+    <?php endif; ?>
+   </div>
+  </div>
+ </div>
+</div>
+<h2>Hizmetleri</h2>
+<table class="table table-bordered">
+ <thead>
+  <tr>
+   <th>Ürün</th><th>Site</th><th>Ödeme Tarihi</th><th>Fiyat</th><th>Ödenen</th><th>Kalan</th><th>İşlem</th>
+  </tr>
+ </thead>
+ <tbody>
+ <?php foreach($services as $s): ?>
+  <tr>
+   <td><?= htmlspecialchars($s['product_name']) ?></td>
+   <td><?= htmlspecialchars($s['site_name']) ?></td>
+   <td><?= date('d.m.Y', strtotime($s['due_date'])) ?></td>
+   <td><?= number_format($s['total_try'],2,',','.') ?> ₺</td>
+   <td><?= number_format($s['paid_try'],2,',','.') ?> ₺</td>
+   <td><?= number_format($s['remaining'],2,',','.') ?> ₺</td>
+   <td>
+    <a href="service.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-info">Detay</a>
+    <a href="service_payment.php?service_id=<?= $s['id'] ?>" class="btn btn-sm btn-primary">Tahsilat</a>
+    <a href="send_reminder.php?service_id=<?= $s['id'] ?>" class="btn btn-sm btn-info">Hatırlatma</a>
+    <a href="service_edit.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+    <a href="service_delete.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+   </td>
+  </tr>
+ <?php endforeach; ?>
+ </tbody>
+</table>
+<h2>Tahsilatlar</h2>
+<table class="table table-bordered">
+ <thead>
+  <tr><th>Hizmet/Site</th><th>Tutar (TL)</th><th>Para Birimi</th><th>Tarih</th></tr>
+ </thead>
+ <tbody>
+  <?php foreach($payments as $p): ?>
+  <tr>
+   <td><?= htmlspecialchars($p['site_name']) ?></td>
+   <td><?= number_format($p['amount_try'],2,',','.') ?> ₺</td>
+   <td><?= htmlspecialchars($p['currency']) ?></td>
+   <td><?= date('d.m.Y', strtotime($p['created_at'])) ?></td>
+  </tr>
+  <?php endforeach; ?>
+ </tbody>
+</table>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/customer_add.php
+++ b/customer_add.php
@@ -1,0 +1,43 @@
+<?php
+require __DIR__.'/includes/auth.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare("INSERT INTO customers (full_name, email, phone, company, address, created_at) VALUES (?, ?, ?, ?, ?, NOW())");
+    $stmt->execute([
+        $_POST['full_name'],
+        $_POST['email'],
+        $_POST['phone'],
+        $_POST['company'],
+        $_POST['address']
+    ]);
+    header('Location: customers.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Müşteri Ekle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ad Soyad</label>
+    <input type="text" name="full_name" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">E-Posta</label>
+    <input type="email" name="email" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Telefon</label>
+    <input type="text" name="phone" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Şirket</label>
+    <input type="text" name="company" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Adres</label>
+    <textarea name="address" class="form-control"></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/customer_delete.php
+++ b/customer_delete.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__.'/includes/auth.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('DELETE FROM customers WHERE id=?');
+$stmt->execute([$id]);
+header('Location: customers.php');
+exit;

--- a/customer_edit.php
+++ b/customer_edit.php
@@ -1,0 +1,54 @@
+<?php
+require __DIR__.'/includes/auth.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
+$stmt->execute([$id]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$customer){
+    header('Location: customers.php');
+    exit;
+}
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $stmt = $pdo->prepare('UPDATE customers SET full_name=?, email=?, phone=?, company=?, address=? WHERE id=?');
+    $stmt->execute([
+        $_POST['full_name'],
+        $_POST['email'],
+        $_POST['phone'],
+        $_POST['company'],
+        $_POST['address'],
+        $id
+    ]);
+    header('Location: customers.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Müşteri Düzenle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ad Soyad</label>
+    <input type="text" name="full_name" class="form-control" value="<?= htmlspecialchars($customer['full_name']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">E-Posta</label>
+    <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($customer['email']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Telefon</label>
+    <input type="text" name="phone" class="form-control" value="<?= htmlspecialchars($customer['phone']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Şirket</label>
+    <input type="text" name="company" class="form-control" value="<?= htmlspecialchars($customer['company']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Adres</label>
+    <textarea name="address" class="form-control"><?= htmlspecialchars($customer['address']) ?></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="customers.php" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/customer_payment.php
+++ b/customer_payment.php
@@ -1,0 +1,61 @@
+<?php
+require __DIR__.'/includes/auth.php';
+
+$customer_id = isset($_GET['customer_id']) ? (int)$_GET['customer_id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
+$stmt->execute([$customer_id]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$customer){
+    header('Location: customers.php');
+    exit;
+}
+
+$rateStmt = $pdo->query("SELECT usd_try FROM exchange_rates ORDER BY rate_date DESC LIMIT 1");
+$usdRate = (float)$rateStmt->fetchColumn();
+$services = $pdo->prepare('SELECT id, service_type, site_name FROM services WHERE customer_id=? ORDER BY id DESC');
+$services->execute([$customer_id]);
+$services = $services->fetchAll(PDO::FETCH_ASSOC);
+$balStmt = $pdo->prepare("SELECT IFNULL(SUM(s.price_try*(1+s.vat_rate/100)),0) - IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.customer_id=c.id),0) FROM customers c LEFT JOIN services s ON s.customer_id=c.id WHERE c.id=? GROUP BY c.id");
+$balStmt->execute([$customer_id]);
+$balance = (float)$balStmt->fetchColumn();
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $amount = (float)$_POST['amount'];
+    $currency = $_POST['currency'];
+    $serviceId = !empty($_POST['service_id']) ? (int)$_POST['service_id'] : null;
+    $amount_try = $currency === 'USD' ? $amount * $usdRate : $amount;
+    $stmt = $pdo->prepare('INSERT INTO payments (customer_id, service_id, amount_try, amount_orig, currency) VALUES (?,?,?,?,?)');
+    $stmt->execute([$customer_id, $serviceId, $amount_try, $amount, $currency]);
+    header('Location: customers.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Tahsilat Yap - <?= htmlspecialchars($customer['full_name']) ?></h1>
+<p><strong>Toplam Borç:</strong> <?= number_format($balance,2,',','.') ?> ₺</p>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Hizmet (opsiyonel)</label>
+    <select name="service_id" class="form-control">
+      <option value="">Genel</option>
+      <?php foreach($services as $s): ?>
+      <option value="<?= $s['id'] ?>"><?= htmlspecialchars($s['service_type'].' - '.$s['site_name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Tutar</label>
+    <input type="text" name="amount" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Para Birimi</label>
+    <select name="currency" class="form-control">
+      <option value="TRY">TL</option>
+      <option value="USD">USD</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="customers.php" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/customer_statement.php
+++ b/customer_statement.php
@@ -1,0 +1,53 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+require __DIR__.'/includes/SimplePDF.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
+$stmt->execute([$id]);
+$customer = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$customer){
+    exit('Müşteri bulunamadı');
+}
+
+$setStmt = $pdo->prepare('SELECT `key`,value FROM settings WHERE `key` IN ("logo")');
+$setStmt->execute();
+$settings = [];
+foreach($setStmt->fetchAll(PDO::FETCH_ASSOC) as $r){
+    $settings[$r['key']] = $r['value'];
+}
+
+$usdRate = getUsdRate($pdo);
+
+$pdf = new SimplePDF();
+$pdf->AddPage();
+$pdf->SetFont('Helvetica','',16);
+if(!empty($settings['logo']) && file_exists($settings['logo'])){
+    $pdf->Image($settings['logo'],10,10,40);
+}
+$pdf->Ln(20);
+$pdf->Cell(190,10,'Hesap Ekstresi',0,1);
+$pdf->SetFont('Helvetica','',12);
+$pdf->Cell(190,8,$customer['full_name'],0,1);
+$pdf->Ln(4);
+$pdf->Cell(40,8,'Tarih');
+$pdf->Cell(110,8,'Açıklama');
+$pdf->Cell(40,8,'Tutar (TL)',0,1);
+
+$svcStmt = $pdo->prepare('SELECT site_name,due_date,price_try,vat_rate FROM services WHERE customer_id=?');
+$svcStmt->execute([$id]);
+while($s = $svcStmt->fetch(PDO::FETCH_ASSOC)){
+    $total = $s['price_try']*(1+$s['vat_rate']/100);
+    $pdf->Cell(40,8,date('d.m.Y',strtotime($s['due_date'])));
+    $pdf->Cell(110,8,'Hizmet: '.$s['site_name']);
+    $pdf->Cell(40,8,number_format($total,2,',','.'),0,1);
+}
+$payStmt = $pdo->prepare('SELECT amount_try,currency,created_at FROM payments WHERE customer_id=?');
+$payStmt->execute([$id]);
+while($p = $payStmt->fetch(PDO::FETCH_ASSOC)){
+    $pdf->Cell(40,8,date('d.m.Y',strtotime($p['created_at'])));
+    $pdf->Cell(110,8,'Tahsilat');
+    $pdf->Cell(40,8,number_format(-$p['amount_try'],2,',','.'),0,1);
+}
+$pdf->Output('ekstre_'.$id.'.pdf');

--- a/customers.php
+++ b/customers.php
@@ -1,0 +1,51 @@
+<?php
+require __DIR__.'/includes/auth.php';
+include __DIR__.'/includes/header.php';
+
+$stmt = $pdo->query("SELECT c.*, 
+    IFNULL(SUM(s.price_try * (1 + s.vat_rate/100)),0) - 
+    IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.customer_id=c.id),0) AS balance
+    FROM customers c
+    LEFT JOIN services s ON s.customer_id = c.id
+    GROUP BY c.id
+    ORDER BY c.id DESC");
+$customers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h1>Müşteriler</h1>
+<a href="customer_add.php" class="btn btn-primary mb-3">Müşteri Ekle</a>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+       <th>ID</th>
+       <th>Ad Soyad</th>
+       <th>E-Posta</th>
+       <th>Telefon</th>
+       <th>Şirket</th>
+       <th>Adres</th>
+       <th>Bakiye (TL)</th>
+       <th>Oluşturma</th>
+       <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($customers as $c): ?>
+    <tr>
+      <td><?= htmlspecialchars($c['id']) ?></td>
+      <td><?= htmlspecialchars($c['full_name']) ?></td>
+      <td><?= htmlspecialchars($c['email']) ?></td>
+      <td><?= htmlspecialchars($c['phone']) ?></td>
+      <td><?= htmlspecialchars($c['company']) ?></td>
+      <td><?= htmlspecialchars($c['address']) ?></td>
+      <td><?= number_format($c['balance'], 2, ',', '.') ?> ₺</td>
+      <td><?= date('d.m.Y', strtotime($c['created_at'])) ?></td>
+      <td>
+        <a href="customer.php?id=<?= $c['id'] ?>" class="btn btn-sm btn-info">Detay</a>
+        <a href="customer_payment.php?customer_id=<?= $c['id'] ?>" class="btn btn-sm btn-success">Tahsilat</a>
+        <a href="customer_edit.php?id=<?= $c['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="customer_delete.php?id=<?= $c['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,314 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$year = isset($_GET['y']) ? (int)$_GET['y'] : (int)date('Y');
+$month = isset($_GET['m']) ? (int)$_GET['m'] : (int)date('n');
+$startMonth = sprintf('%04d-%02d-01', $year, $month);
+$endMonth = date('Y-m-t', strtotime($startMonth));
+
+$events = [];
+$monthTotal = 0;
+$provEvents = [];
+$provUpcomingTotal = 0;
+$rows = $pdo->query("SELECT s.id,s.site_name,c.full_name,s.due_date,
+ (s.price_try*(1+s.vat_rate/100) - IFNULL((SELECT SUM(amount_try) FROM payments WHERE service_id=s.id),0)) AS remain
+ FROM services s JOIN customers c ON s.customer_id=c.id")->fetchAll(PDO::FETCH_ASSOC);
+foreach($rows as $r){
+    if($r['remain']<=0) continue;
+    if($r['due_date'] >= $startMonth && $r['due_date'] <= $endMonth){
+        $day = (int)date('j', strtotime($r['due_date']));
+        $events[$day][] = $r;
+        $monthTotal += $r['remain'];
+    } elseif(date('Y-m',strtotime($r['due_date']))==date('Y-m')) {
+        $monthTotal += $r['remain'];
+    }
+}
+
+$provRows = $pdo->query("SELECT pp.id,pp.item_name,pp.payment_date,pp.price_try,p.name AS provider FROM provider_purchases pp JOIN providers p ON pp.provider_id=p.id")->fetchAll(PDO::FETCH_ASSOC);
+foreach($provRows as $pr){
+    if($pr['payment_date'] >= $startMonth && $pr['payment_date'] <= $endMonth){
+        $day=(int)date('j',strtotime($pr['payment_date']));
+        $provEvents[$day][]=$pr;
+    }
+    if($pr['payment_date']>=date('Y-m-d') && $pr['payment_date']<=date('Y-m-d',strtotime('+30 days'))){
+        $provUpcomingTotal += $pr['price_try'];
+    }
+}
+
+$overallTotal = (float)$pdo->query("SELECT SUM(s.price_try*(1+s.vat_rate/100) - IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.service_id=s.id),0)) FROM services s")->fetchColumn();
+$customerCount = (int)$pdo->query("SELECT COUNT(*) FROM customers")->fetchColumn();
+$serviceCount = (int)$pdo->query("SELECT COUNT(*) FROM services")->fetchColumn();
+$topServices = $pdo->query("SELECT service_type, COUNT(*) c FROM services GROUP BY service_type ORDER BY c DESC LIMIT 5")->fetchAll(PDO::FETCH_ASSOC);
+$recent = $pdo->query("SELECT s.id,c.full_name,s.site_name FROM services s JOIN customers c ON s.customer_id=c.id ORDER BY s.created_at DESC LIMIT 5")->fetchAll(PDO::FETCH_ASSOC);
+$rateRow = $pdo->query("SELECT rate_date, usd_try FROM exchange_rates ORDER BY rate_date DESC LIMIT 1")->fetch(PDO::FETCH_ASSOC);
+
+$upcoming = $pdo->query("SELECT s.id,s.site_name,c.full_name,s.due_date FROM services s JOIN customers c ON s.customer_id=c.id WHERE s.due_date >= CURDATE() ORDER BY s.due_date ASC LIMIT 10")->fetchAll(PDO::FETCH_ASSOC);
+$upcomingProv = $pdo->query("SELECT pp.id,pp.item_name,p.name AS provider,pp.payment_date FROM provider_purchases pp JOIN providers p ON pp.provider_id=p.id WHERE pp.payment_date >= CURDATE() ORDER BY pp.payment_date ASC LIMIT 10")->fetchAll(PDO::FETCH_ASSOC);
+
+$months = ['Ocak','Şubat','Mart','Nisan','Mayıs','Haziran','Temmuz','Ağustos','Eylül','Ekim','Kasım','Aralık'];
+$monthName = $months[$month-1];
+$prevM = $month-1; $prevY = $year; if($prevM<1){$prevM=12;$prevY--;}
+$nextM = $month+1; $nextY = $year; if($nextM>12){$nextM=1;$nextY++;}
+$startDow = (int)date('N', strtotime($startMonth)); // 1=Mon
+$daysInMonth = (int)date('t', strtotime($startMonth));
+$weeks = ceil(($startDow-1 + $daysInMonth)/7);
+
+$eventsJs = [];
+foreach($events as $d=>$evs){
+    foreach($evs as $e){
+        $eventsJs[$d][] = ['site'=>$e['site_name'],'customer'=>$e['full_name'],'due'=>$e['due_date']];
+    }
+}
+$provEventsJs = [];
+foreach($provEvents as $d=>$evs){
+    foreach($evs as $e){
+        $provEventsJs[$d][] = ['item'=>$e['item_name'],'provider'=>$e['provider'],'due'=>$e['payment_date']];
+    }
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<div class="row mb-4">
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Bu Ay Alınacak</h5><p class="card-text fw-bold"><?= number_format($monthTotal,2,',','.') ?> ₺</p></div></div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Toplam Alacak</h5><p class="card-text fw-bold"><?= number_format($overallTotal,2,',','.') ?> ₺</p></div></div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Müşteri Sayısı</h5><p class="card-text fw-bold"><?= $customerCount ?></p></div></div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Hizmet Sayısı</h5><p class="card-text fw-bold"><?= $serviceCount ?></p></div></div>
+  </div>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Yapılacak Ödemeler (30g)</h5><p class="card-text fw-bold"><?= number_format($provUpcomingTotal,2,',','.') ?> ₺</p></div></div>
+  </div>
+  <?php if ($rateRow): ?>
+  <div class="col-md-3">
+    <div class="card text-bg-light mb-3"><div class="card-body"><h5 class="card-title">Güncel Kur</h5><p class="card-text fw-bold"><?= number_format($rateRow['usd_try'],4,',','.') ?> (<?= htmlspecialchars($rateRow['rate_date']) ?>)</p></div></div>
+  </div>
+  <?php endif; ?>
+</div>
+<ul class="nav nav-tabs" id="dashTabs" role="tablist">
+  <li class="nav-item" role="presentation"><button class="nav-link active" id="cust-tab" data-bs-toggle="tab" data-bs-target="#cust" type="button" role="tab">Müşteriler</button></li>
+  <li class="nav-item" role="presentation"><button class="nav-link" id="prov-tab" data-bs-toggle="tab" data-bs-target="#prov" type="button" role="tab">Sağlayıcılar</button></li>
+</ul>
+<div class="tab-content">
+<div class="tab-pane fade show active" id="cust" role="tabpanel" aria-labelledby="cust-tab">
+<div class="row">
+  <div class="col-lg-8 mb-4">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <div>
+        <a class="btn btn-sm btn-outline-secondary" href="?y=<?= $prevY ?>&m=<?= $prevM ?>">&lt;</a>
+        <strong class="mx-2"><?= $monthName.' '.$year ?></strong>
+        <a class="btn btn-sm btn-outline-secondary" href="?y=<?= $nextY ?>&m=<?= $nextM ?>">&gt;</a>
+      </div>
+      <a class="btn btn-sm btn-outline-primary" href="?">Bugün</a>
+    </div>
+    <table class="table calendar table-bordered text-center">
+      <thead><tr><th>Pzt</th><th>Sal</th><th>Çar</th><th>Per</th><th>Cum</th><th>Cmt</th><th>Paz</th></tr></thead>
+      <tbody>
+      <?php
+      $day = 1 - ($startDow-1);
+      for($w=0;$w<$weeks;$w++):
+          echo "<tr>";
+          for($d=1;$d<=7;$d++):
+              if($day<1 || $day>$daysInMonth){
+                  echo '<td class="bg-light"></td>';
+              } else {
+                  $has = !empty($events[$day]);
+                  echo '<td class="calendar-day" data-day="'.$day.'">';
+                  echo '<div class="day-number">'.$day.'</div>';
+                  if($has){
+                      foreach($events[$day] as $ev){
+                          $diff = floor((strtotime($ev['due_date'])-time())/86400);
+                          $cls = $diff<0?'bg-danger':($diff<=14?'bg-orange':($diff<=30?'bg-warning':'bg-success'));
+                          echo '<div class="event '.$cls.'" title="'.htmlspecialchars($ev['site_name'],ENT_QUOTES).'"></div>';
+                      }
+                  }
+                  echo '</td>';
+              }
+              $day++;
+          endfor;
+          echo "</tr>";
+      endfor;
+      ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="col-lg-4">
+    <input type="text" id="search" class="form-control mb-2" placeholder="Veriler içinde arama yap">
+    <div class="list-group" id="upcomingList" style="max-height:400px;overflow:auto;">
+      <?php foreach($upcoming as $u):
+            $diff=floor((strtotime($u['due_date'])-time())/86400);
+            $cls=$diff<0?'bg-danger':($diff<=14?'bg-orange':($diff<=30?'bg-warning':'bg-success'));
+            $txt=$diff>=0?'+'.$diff.' gün kaldı':abs($diff).' gün geçti';
+      ?>
+      <a href="service.php?id=<?= $u['id'] ?>" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" data-search="<?= strtolower($u['site_name'].' '.$u['full_name']) ?>">
+        <span>
+          <strong><?= htmlspecialchars($u['site_name']) ?></strong><br>
+          <small><?= htmlspecialchars($u['full_name']) ?></small>
+        </span>
+        <span class="badge text-light <?= $cls ?>"><?= $txt ?></span>
+      </a>
+      <?php endforeach; ?>
+    </div>
+  </div>
+</div>
+</div>
+<div class="tab-pane fade" id="prov" role="tabpanel" aria-labelledby="prov-tab">
+<div class="row">
+  <div class="col-lg-8 mb-4">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <div>
+        <a class="btn btn-sm btn-outline-secondary" href="?y=<?= $prevY ?>&m=<?= $prevM ?>">&lt;</a>
+        <strong class="mx-2"><?= $monthName.' '.$year ?></strong>
+        <a class="btn btn-sm btn-outline-secondary" href="?y=<?= $nextY ?>&m=<?= $nextM ?>">&gt;</a>
+      </div>
+      <a class="btn btn-sm btn-outline-primary" href="?">Bugün</a>
+    </div>
+    <table class="table calendar table-bordered text-center" id="provCal">
+      <thead><tr><th>Pzt</th><th>Sal</th><th>Çar</th><th>Per</th><th>Cum</th><th>Cmt</th><th>Paz</th></tr></thead>
+      <tbody>
+      <?php
+      $day = 1 - ($startDow-1);
+      for($w=0;$w<$weeks;$w++):
+          echo "<tr>";
+          for($d=1;$d<=7;$d++):
+              if($day<1 || $day>$daysInMonth){
+                  echo '<td class="bg-light"></td>';
+              } else {
+                  $has = !empty($provEvents[$day]);
+                  echo '<td class="calendar-day" data-day="'.$day.'">';
+                  echo '<div class="day-number">'.$day.'</div>';
+                  if($has){
+                      foreach($provEvents[$day] as $ev){
+                          $diff=floor((strtotime($ev['payment_date'])-time())/86400);
+                          $cls=$diff<0?'bg-danger':($diff<=14?'bg-orange':($diff<=30?'bg-warning':'bg-success'));
+                          echo '<div class="event '.$cls.'" title="'.htmlspecialchars($ev['item_name'],ENT_QUOTES).'"></div>';
+                      }
+                  }
+                  echo '</td>';
+              }
+              $day++;
+          endfor;
+          echo "</tr>";
+      endfor;
+      ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="col-lg-4">
+    <input type="text" id="searchProv" class="form-control mb-2" placeholder="Veriler içinde arama yap">
+    <div class="list-group" id="upcomingProvList" style="max-height:400px;overflow:auto;">
+      <?php foreach($upcomingProv as $u):
+            $diff=floor((strtotime($u['payment_date'])-time())/86400);
+            $cls=$diff<0?'bg-danger':($diff<=14?'bg-orange':($diff<=30?'bg-warning':'bg-success'));
+            $txt=$diff>=0?'+'.$diff.' gün kaldı':abs($diff).' gün geçti';
+      ?>
+      <div class="list-group-item d-flex justify-content-between align-items-center" data-search="<?= strtolower($u['item_name'].' '.$u['provider']) ?>">
+        <span>
+          <strong><?= htmlspecialchars($u['item_name']) ?></strong><br>
+          <small><?= htmlspecialchars($u['provider']) ?></small>
+        </span>
+        <span class="badge text-light <?= $cls ?>"><?= $txt ?></span>
+      </div>
+      <?php endforeach; ?>
+    </div>
+  </div>
+</div>
+</div>
+</div>
+<div class="modal fade" id="dayModal" tabindex="-1">
+  <div class="modal-dialog"><div class="modal-content">
+    <div class="modal-header"><h5 class="modal-title">Gün Detayları</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+    <div class="modal-body" id="dayModalBody"></div>
+  </div></div>
+</div>
+<h2 class="mt-5">Analizler</h2>
+<div class="row">
+  <div class="col-md-6 mb-4">
+    <div class="card shadow-sm">
+      <div class="card-header bg-primary text-white">En Çok Satan Hizmetler</div>
+      <ul class="list-group list-group-flush">
+        <?php foreach($topServices as $t): ?>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <?= htmlspecialchars($t['service_type']) ?>
+          <span class="badge bg-secondary"><?= $t['c'] ?></span>
+        </li>
+        <?php endforeach; ?>
+      </ul>
+    </div>
+  </div>
+  <div class="col-md-6 mb-4">
+    <div class="card shadow-sm">
+      <div class="card-header bg-primary text-white">Son Eklenen Hizmetler</div>
+      <ul class="list-group list-group-flush">
+        <?php foreach($recent as $r): ?>
+        <li class="list-group-item"><a href="service.php?id=<?= $r['id'] ?>"><?= htmlspecialchars($r['full_name'].' - '.$r['site_name']) ?></a></li>
+        <?php endforeach; ?>
+      </ul>
+    </div>
+  </div>
+</div>
+<style>
+.calendar{background:#fff;border-radius:8px;box-shadow:0 5px 15px rgba(0,0,0,0.1);} 
+.calendar-day{height:80px;vertical-align:top;cursor:pointer;transition:transform .2s;}
+.calendar-day:hover{transform:scale(1.05);} 
+.day-number{font-weight:500;text-align:right;}
+.event{height:6px;border-radius:3px;margin-top:2px;}
+.bg-orange{background-color:#fd7e14!important;color:#fff;}
+</style>
+<script>
+var events = <?= json_encode($eventsJs) ?>;
+document.querySelectorAll('#cust .calendar-day').forEach(function(td){
+  td.addEventListener('click',function(){
+    var d=this.dataset.day;
+    if(!events[d]) return;
+    var html='';
+    events[d].forEach(function(ev){
+      var due=new Date(ev.due);
+      var today=new Date();
+      today.setHours(0,0,0,0);
+      var diff=Math.floor((due-today)/86400000);
+      var txt=(diff>=0?"+"+diff+" gün kaldı":Math.abs(diff)+" gün geçti");
+      html+='<p><strong>'+ev.site+'</strong> - '+ev.customer+' ('+txt+')</p>';
+    });
+    document.getElementById('dayModalBody').innerHTML=html;
+    new bootstrap.Modal(document.getElementById('dayModal')).show();
+  });
+});
+var eventsProv = <?= json_encode($provEventsJs) ?>;
+document.querySelectorAll('#prov .calendar-day').forEach(function(td){
+  td.addEventListener('click',function(){
+    var d=this.dataset.day;
+    if(!eventsProv[d]) return;
+    var html='';
+    eventsProv[d].forEach(function(ev){
+      var due=new Date(ev.due);
+      var today=new Date();
+      today.setHours(0,0,0,0);
+      var diff=Math.floor((due-today)/86400000);
+      var txt=(diff>=0?"+"+diff+" gün kaldı":Math.abs(diff)+" gün geçti");
+      html+='<p><strong>'+ev.item+'</strong> - '+ev.provider+' ('+txt+')</p>';
+    });
+    document.getElementById('dayModalBody').innerHTML=html;
+    new bootstrap.Modal(document.getElementById('dayModal')).show();
+  });
+});
+document.getElementById('search').addEventListener('input',function(){
+  var t=this.value.toLowerCase();
+  document.querySelectorAll('#upcomingList [data-search]').forEach(function(a){
+    a.style.display=a.dataset.search.includes(t)?'':'none';
+  });
+});
+document.getElementById('searchProv').addEventListener('input',function(){
+  var t=this.value.toLowerCase();
+  document.querySelectorAll('#upcomingProvList [data-search]').forEach(function(a){
+    a.style.display=a.dataset.search.includes(t)?'':'none';
+  });
+});
+</script>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/email_settings.php
+++ b/email_settings.php
@@ -1,0 +1,101 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require_once __DIR__.'/includes/functions.php';
+
+$keys = ['mail_logo','smtp_host','smtp_port','smtp_encryption','smtp_user','smtp_pass','smtp_from_name','smtp_from_email'];
+$settings=[];
+foreach($keys as $k){
+    $stmt=$pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt->execute([$k]);
+    $settings[$k]=$stmt->fetchColumn() ?: '';
+}
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    if(!empty($_FILES['mail_logo']['tmp_name'])){
+        $dir='uploads';
+        if(!is_dir($dir)) mkdir($dir,0777,true);
+        $path=$dir.'/'.basename($_FILES['mail_logo']['name']);
+        move_uploaded_file($_FILES['mail_logo']['tmp_name'],$path);
+        $stmt=$pdo->prepare("REPLACE INTO settings (`key`,value) VALUES ('mail_logo',?)");
+        $stmt->execute([$path]);
+        $settings['mail_logo']=$path;
+    }
+    foreach(['smtp_host','smtp_port','smtp_encryption','smtp_user','smtp_pass','smtp_from_name','smtp_from_email'] as $k){
+        if(isset($_POST[$k])){
+            $stmt=$pdo->prepare("REPLACE INTO settings (`key`,value) VALUES (?,?)");
+            $stmt->execute([$k,$_POST[$k]]);
+            $settings[$k]=$_POST[$k];
+        }
+    }
+    $save_message='Ayarlar kaydedildi';
+    if(isset($_POST['send_test']) && !empty($_POST['test_email'])){
+        $err='';
+        $sent=sendMail($pdo,$_POST['test_email'],'Test','Bu bir test e-postasidir.',$err,null,null);
+        $test_message=$sent ? 'Test maili gönderildi' : 'Gönderim başarısız: '.$err;
+    }
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>E-posta Ayarları</h1>
+<form method="post" enctype="multipart/form-data">
+  <div class="mb-3">
+    <label class="form-label">Mail Logosu</label>
+    <input type="file" name="mail_logo" class="form-control">
+  </div>
+  <?php if($settings['mail_logo']): ?>
+  <div class="mb-3">
+    <img src="/<?= htmlspecialchars($settings['mail_logo']) ?>" alt="Logo" style="max-width:200px;">
+  </div>
+  <?php endif; ?>
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Gönderen Adı</label>
+      <input type="text" name="smtp_from_name" class="form-control" value="<?= htmlspecialchars($settings['smtp_from_name']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Gönderen E-Posta</label>
+      <input type="email" name="smtp_from_email" class="form-control" value="<?= htmlspecialchars($settings['smtp_from_email']) ?>">
+    </div>
+    <div class="col-md-4 mb-3">
+      <label class="form-label">Sunucu</label>
+      <input type="text" name="smtp_host" class="form-control" value="<?= htmlspecialchars($settings['smtp_host']) ?>">
+    </div>
+    <div class="col-md-2 mb-3">
+      <label class="form-label">Port</label>
+      <input type="number" name="smtp_port" class="form-control" value="<?= htmlspecialchars($settings['smtp_port']) ?>">
+    </div>
+    <div class="col-md-2 mb-3">
+      <label class="form-label">Şifreleme</label>
+      <select name="smtp_encryption" class="form-control">
+        <option value="ssl" <?= $settings['smtp_encryption']==='ssl'?'selected':'' ?>>SSL</option>
+        <option value="tls" <?= $settings['smtp_encryption']==='tls'?'selected':'' ?>>TLS</option>
+      </select>
+    </div>
+    <div class="col-md-4 mb-3">
+      <label class="form-label">Kullanıcı Adı</label>
+      <input type="text" name="smtp_user" class="form-control" value="<?= htmlspecialchars($settings['smtp_user']) ?>">
+    </div>
+    <div class="col-md-4 mb-3">
+      <label class="form-label">Şifre</label>
+      <input type="password" name="smtp_pass" class="form-control" value="<?= htmlspecialchars($settings['smtp_pass']) ?>">
+    </div>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php if(!empty($save_message)): ?>
+<div class="alert alert-success mt-3">
+  <?= $save_message ?>
+</div>
+<?php endif; ?>
+<h2 class="mt-4">Mail Testi</h2>
+<?php if(!empty($test_message)): ?>
+<div class="alert alert-info"><?= $test_message ?></div>
+<?php endif; ?>
+<form method="post">
+  <div class="input-group mb-3">
+    <input type="email" name="test_email" class="form-control" placeholder="E-posta" required>
+    <button type="submit" name="send_test" value="1" class="btn btn-secondary">Test Mail Gönder</button>
+  </div>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/exchange_rates.php
+++ b/exchange_rates.php
@@ -1,0 +1,26 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$stmt = $pdo->query('SELECT * FROM exchange_rates ORDER BY rate_date DESC');
+$rates = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Kur Bilgisi</h1>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>Tarih</th>
+      <th>USD/TRY</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($rates as $r): ?>
+    <tr>
+      <td><?= htmlspecialchars($r['rate_date']) ?></td>
+      <td><?= number_format($r['usd_try'], 4, ',', '.') ?></td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/exchange_rates_cron.php
+++ b/exchange_rates_cron.php
@@ -1,0 +1,23 @@
+<?php
+require __DIR__.'/includes/db.php';
+
+$xml = @simplexml_load_file('https://www.tcmb.gov.tr/kurlar/today.xml');
+if ($xml) {
+    foreach ($xml->Currency as $currency) {
+        if ((string)$currency['CurrencyCode'] === 'USD') {
+            $rate = str_replace(',', '.', (string)$currency->BanknoteSelling);
+            $exists = $pdo->prepare('SELECT id FROM exchange_rates WHERE rate_date = CURDATE()');
+            $exists->execute();
+            if (!$exists->fetch()) {
+                $stmt = $pdo->prepare("INSERT INTO exchange_rates (rate_date, usd_try) VALUES (CURDATE(), ?)");
+                $stmt->execute([$rate]);
+                echo "Günlük kur kaydedildi: $rate";
+            } else {
+                echo "Kur zaten kayıtlı";
+            }
+            break;
+        }
+    }
+} else {
+    echo "Kur verisi alınamadı";
+}

--- a/includes/PHPMailer.php
+++ b/includes/PHPMailer.php
@@ -1,0 +1,73 @@
+<?php
+class PHPMailer {
+    public $Host;
+    public $Port = 25;
+    public $SMTPSecure;
+    public $Username;
+    public $Password;
+    public $From;
+    public $FromName;
+    public $Subject;
+    public $Body;
+    public $CharSet = 'UTF-8';
+    private $to = [];
+    public $ErrorInfo = '';
+
+    public function addAddress($addr){
+        $this->to[] = $addr;
+    }
+    private function sendCmd($fp,$cmd,$expect=true){
+        if($cmd!==null){
+            fwrite($fp,$cmd."\r\n");
+        }
+        $resp='';
+        while(($line=fgets($fp,512))!==false){
+            $resp.=$line;
+            if(strlen($line)>3 && $line[3]!== '-') break;
+        }
+        if($expect){
+            $code=(int)substr($resp,0,3);
+            if($code>=400){
+                $this->ErrorInfo=trim($resp);
+                return false;
+            }
+        }
+        return true;
+    }
+    public function send(){
+        $host = ($this->SMTPSecure==='ssl'?'ssl://':'').$this->Host;
+        $fp = fsockopen($host,$this->Port,$errno,$errstr,10);
+        if(!$fp){
+            $this->ErrorInfo = $errstr ?: 'Bağlantı kurulamadı';
+            return false;
+        }
+        if(!$this->sendCmd($fp,null)) return false; // server greeting
+        if(!$this->sendCmd($fp, 'EHLO localhost')) return false;
+        if($this->SMTPSecure==='tls'){
+            if(!$this->sendCmd($fp,'STARTTLS')) return false;
+            stream_socket_enable_crypto($fp,true,STREAM_CRYPTO_METHOD_TLS_CLIENT);
+            if(!$this->sendCmd($fp,'EHLO localhost')) return false;
+        }
+        if(!$this->sendCmd($fp,'AUTH LOGIN')) return false;
+        if(!$this->sendCmd($fp,base64_encode($this->Username))) return false;
+        if(!$this->sendCmd($fp,base64_encode($this->Password))) return false;
+        if(!$this->sendCmd($fp,'MAIL FROM:<'.$this->From.'>')) return false;
+        foreach($this->to as $t){
+            if(!$this->sendCmd($fp,'RCPT TO:<'.$t.'>')) return false;
+        }
+        if(!$this->sendCmd($fp,'DATA')) return false;
+        $headers = "From: {$this->FromName} <{$this->From}>\r\n".
+                   "MIME-Version: 1.0\r\n".
+                   "Content-Type: text/html; charset={$this->CharSet}\r\n";
+        $msg = $headers.
+               "Subject: {$this->Subject}\r\n".
+               "To: ".implode(',', $this->to)."\r\n\r\n".
+               $this->Body;
+        fwrite($fp,$msg."\r\n.\r\n");
+        if(!$this->sendCmd($fp,null)) return false;
+        $this->sendCmd($fp,'QUIT',false);
+        fclose($fp);
+        return true;
+    }
+}
+?>

--- a/includes/SimplePDF.php
+++ b/includes/SimplePDF.php
@@ -1,0 +1,81 @@
+<?php
+class SimplePDF{
+    protected array $pages=[];
+    protected string $content='';
+    protected int $page=0;
+    protected float $w=210;
+    protected float $h=297;
+    protected float $k=72/25.4;
+    protected float $x=10;
+    protected float $y=287;
+    protected int $fontSize=12;
+    protected ?array $imageInfo=null;
+    protected string $imageData='';
+    public function AddPage(){
+        $this->page++;
+        $this->content='';
+        $this->x=10;
+        $this->y=$this->h-10;
+    }
+    public function SetFont(string $family='Helvetica',string $style='',int $size=12){
+        $this->fontSize=$size;
+    }
+    protected function escape(string $s):string{
+        return str_replace(['\\','(',')'],['\\\\','\(','\)'],$s);
+    }
+    public function Cell(float $w,float $h,string $txt='',int $ln=0){
+        $txt=$this->escape($txt);
+        $this->content.=sprintf("BT /F1 %d Tf %.2f %.2f Td (%s) Tj ET\n",
+            $this->fontSize,$this->x*$this->k,($this->h-$this->y)*$this->k,$txt);
+        $this->x+=$w;
+        if($ln>0){
+            $this->x=10;
+            $this->y-=$h;
+        }
+    }
+    public function Ln(float $h=5){
+        $this->x=10;
+        $this->y-=$h;
+    }
+    public function Image(string $file,float $x,float $y,float $w){
+        $data=@file_get_contents($file);
+        if(!$data) return;
+        $info=@getimagesize($file);
+        if(!$info) return;
+        $h=$w*$info[1]/$info[0];
+        $this->imageData=$data;
+        $this->imageInfo=['w'=>$info[0],'h'=>$info[1],'type'=>strpos($info['mime'],'png')!==false?'FlateDecode':'DCTDecode'];
+        $this->content.=sprintf("q %.2f 0 0 %.2f %.2f %.2f cm /I1 Do Q\n",
+            $w*$this->k,$h*$this->k,$x*$this->k,($this->h-$y-$h)*$this->k);
+    }
+    public function Output(string $name='document.pdf'){
+        $objects=[];
+        $objects[]="<< /Type /Catalog /Pages 2 0 R >>";
+        $objects[]="<< /Type /Pages /Kids [4 0 R] /Count 1 >>";
+        $objects[]="<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+        $resources="<< /Font << /F1 3 0 R >>";
+        if($this->imageData) $resources.=" /XObject << /I1 6 0 R >>";
+        $resources.=" >>";
+        $objects[]="<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ".($this->w*$this->k)." ".($this->h*$this->k)."] /Contents 5 0 R /Resources $resources >>";
+        $objects[]="<< /Length ".strlen($this->content)." >>\nstream\n".$this->content."endstream";
+        if($this->imageData){
+            $objects[]="<< /Type /XObject /Subtype /Image /Width {$this->imageInfo['w']} /Height {$this->imageInfo['h']} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /{$this->imageInfo['type']} /Length ".strlen($this->imageData)." >>\nstream\n".$this->imageData."\nendstream";
+        }
+        $pdf="%PDF-1.4\n";
+        $xref="xref\n0 ".(count($objects)+1)."\n0000000000 65535 f \n";
+        $offset=0; $i=1;
+        foreach($objects as $obj){
+            $offset+=strlen($pdf);
+            $xref.=sprintf("%010d 00000 n \n",$offset);
+            $pdf.="$i 0 obj\n$obj\nendobj\n";
+            $i++;
+        }
+        $start=strlen($pdf);
+        $pdf.=$xref;
+        $pdf.="trailer\n<< /Root 1 0 R /Size ".(count($objects)+1)." >>\nstartxref\n$start\n%%EOF";
+        header('Content-Type: application/pdf');
+        header('Content-Disposition: attachment; filename="'.$name.'"');
+        echo $pdf;
+    }
+}
+?>

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/db.php';
+
+session_start();
+
+if (!isset($_SESSION['user_id']) || (time() - ($_SESSION['last_active'] ?? 0) > 1800)) {
+    session_unset();
+    session_destroy();
+    header('Location: /login.php');
+    exit;
+}
+
+$_SESSION['last_active'] = time();
+?>

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,11 @@
+<?php
+$config = include __DIR__ . '/../config/config.php';
+
+$dsn = "mysql:host={$config['db']['host']};dbname={$config['db']['dbname']};charset={$config['db']['charset']}";
+
+try {
+    $pdo = new PDO($dsn, $config['db']['user'], $config['db']['pass']);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+    die('Veritabanı bağlantı hatası: ' . $e->getMessage());
+}

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,20 @@
+<?php
+$fSettings = [];
+foreach(['footer_text','footer_logo','footer_logo_width','footer_logo_height'] as $fk){
+    $st=$pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $st->execute([$fk]);
+    $fSettings[$fk]=$st->fetchColumn() ?: '';
+}
+?>
+</div>
+<footer class="bg-light py-3 mt-5">
+  <div class="container d-flex justify-content-between align-items-center">
+    <div><?= htmlspecialchars($fSettings['footer_text'] ?: 'Precad Medya 2025 Tüm Hakları Saklıdır.') ?></div>
+    <?php if($fSettings['footer_logo']): ?>
+      <img src="<?= htmlspecialchars($fSettings['footer_logo']) ?>" style="width:<?= (int)$fSettings['footer_logo_width'] ?>px;height:<?= (int)$fSettings['footer_logo_height'] ?>px;object-fit:contain;" alt="footer logo">
+    <?php endif; ?>
+  </div>
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,82 @@
+<?php
+function getUsdRate(PDO $pdo): float {
+    $stmt = $pdo->query("SELECT usd_try FROM exchange_rates ORDER BY rate_date DESC LIMIT 1");
+    $rate = (float)$stmt->fetchColumn();
+    if($rate){
+        return $rate;
+    }
+    $xml = @simplexml_load_file('https://www.tcmb.gov.tr/kurlar/today.xml');
+    if($xml){
+        foreach($xml->Currency as $cur){
+            if((string)$cur['CurrencyCode']=='USD'){
+                $rate = (float)str_replace(',', '.', (string)$cur->BanknoteSelling);
+                if($rate){
+                    $ins = $pdo->prepare('INSERT INTO exchange_rates(rate_date,usd_try) VALUES (CURDATE(), ?)');
+                    $ins->execute([$rate]);
+                }
+                break;
+            }
+        }
+    }
+    return $rate ?: 0.0;
+}
+
+function getEmailSettings(PDO $pdo): array {
+    $defaults = include __DIR__ . '/../config/config.php';
+    $settings = [];
+    $stmt = $pdo->prepare("SELECT `key`, value FROM settings WHERE `key` IN ('smtp_host','smtp_port','smtp_encryption','smtp_user','smtp_pass','smtp_from_name','smtp_from_email','mail_logo')");
+    $stmt->execute();
+    foreach($stmt->fetchAll(PDO::FETCH_KEY_PAIR) as $k=>$v){
+        $settings[$k] = $v;
+    }
+    return [
+        'host' => $settings['smtp_host'] ?? $defaults['smtp']['host'],
+        'port' => (int)($settings['smtp_port'] ?? $defaults['smtp']['port']),
+        'encryption' => $settings['smtp_encryption'] ?? $defaults['smtp']['encryption'],
+        'username' => $settings['smtp_user'] ?? $defaults['smtp']['username'],
+        'password' => $settings['smtp_pass'] ?? $defaults['smtp']['password'],
+        'from_name' => $settings['smtp_from_name'] ?? $defaults['smtp']['from_name'],
+        'from_email' => $settings['smtp_from_email'] ?? $defaults['smtp']['from_email'],
+        'logo' => $settings['mail_logo'] ?? ''
+    ];
+}
+
+function sendMail(PDO $pdo, string $to, string $subject, string $body, string &$error = '', ?int $serviceId = null, ?int $clientId = null): bool {
+    require_once __DIR__ . '/PHPMailer.php';
+    $smtp = getEmailSettings($pdo);
+    $fromEmail = trim($smtp['from_email'] ?? '');
+    $fromName  = trim($smtp['from_name'] ?? '');
+    if ($fromEmail === '') $fromEmail = 'info@precadmedya.com.tr';
+    if ($fromName === '')  $fromName = 'Precad Medya';
+    $subject = trim($subject);
+    if ($subject === '') $subject = 'Ödeme Hatırlatma';
+
+    $mail = new PHPMailer();
+    $mail->Host       = $smtp['host'];
+    $mail->Port       = $smtp['port'];
+    $mail->SMTPSecure = $smtp['encryption'];
+    $mail->Username   = $smtp['username'];
+    $mail->Password   = $smtp['password'];
+    $mail->From       = $fromEmail;
+    $mail->FromName   = $fromName;
+    $mail->Subject    = $subject;
+    if($smtp['logo']){
+        $src = $smtp['logo'];
+        if(file_exists($src)){
+            $ext = pathinfo($src, PATHINFO_EXTENSION);
+            $data = base64_encode(file_get_contents($src));
+            $src = 'data:image/'.$ext.';base64,'.$data;
+        }
+        $body = '<div><img src="'.$src.'" style="max-width:200px;height:auto;"></div><br>'.$body;
+    }
+    $mail->Body = $body;
+    $mail->addAddress($to);
+    $ok = $mail->send();
+    if(!$ok){
+        $error = $mail->ErrorInfo ?: 'Bilinmeyen hata';
+    }
+    $log = $pdo->prepare('INSERT INTO email_logs(service_id,client_id,email_to,subject,content,sent_at) VALUES (?,?,?,?,?,NOW())');
+    $log->execute([$serviceId,$clientId,$to,$subject,$body]);
+    return $ok;
+}
+?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Takip Sistemi</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<?php
+require_once __DIR__.'/functions.php';
+$settings = [];
+foreach (['logo','logo_header_width','logo_header_height'] as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt->execute([$k]);
+    $settings[$k] = $stmt->fetchColumn() ?: '';
+}
+$currentRate = getUsdRate($pdo);
+?>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+ <div class="container-fluid">
+  <a class="navbar-brand me-3" href="dashboard.php">
+    <?php if ($settings['logo']): ?>
+      <img src="<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" style="width:<?= (int)$settings['logo_header_width'] ?>px;height:<?= (int)$settings['logo_header_height'] ?>px;object-fit:contain;">
+    <?php else: ?>Takip Sistemi<?php endif; ?>
+  </a>
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse justify-content-center" id="mainNav">
+   <ul class="navbar-nav mb-2 mb-lg-0">
+    <li class="nav-item"><a class="nav-link" href="dashboard.php">Anasayfa</a></li>
+    <li class="nav-item"><a class="nav-link" href="customers.php">Müşteriler</a></li>
+    <li class="nav-item"><a class="nav-link" href="services.php">Hizmetler</a></li>
+    <li class="nav-item"><a class="nav-link" href="products.php">Ürünler</a></li>
+    <li class="nav-item"><a class="nav-link" href="providers.php">Sağlayıcılar</a></li>
+    <li class="nav-item"><a class="nav-link" href="purchase_add.php">Ürün Satın Al</a></li>
+    <li class="nav-item dropdown">
+      <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Ayarlar</a>
+      <ul class="dropdown-menu">
+        <li><a class="dropdown-item" href="settings.php">Genel Ayarlar</a></li>
+        <li><a class="dropdown-item" href="email_settings.php">E-posta Ayarları</a></li>
+        <li><a class="dropdown-item" href="users.php">Kullanıcılar</a></li>
+      </ul>
+    </li>
+   </ul>
+   <span class="navbar-text me-3">Kur: <?= number_format($currentRate,4,',','.') ?></span>
+   <a href="update_rates.php" class="btn btn-warning btn-sm me-3">Kur Güncelle</a>
+   <a href="logout.php" class="btn btn-outline-secondary">Çıkış</a>
+  </div>
+</div>
+</nav>
+<div class="container mt-4">
+<?php if(!empty($_SESSION['message'])): ?>
+  <div class="alert alert-success">
+    <?= $_SESSION['message']; unset($_SESSION['message']); ?>
+  </div>
+<?php endif; ?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+if (isset($_SESSION['user_id']) && (time() - ($_SESSION['last_active'] ?? 0) < 1800)) {
+    header('Location: dashboard.php');
+} else {
+    header('Location: login.php');
+}

--- a/login.php
+++ b/login.php
@@ -1,0 +1,66 @@
+<?php
+require __DIR__ . '/includes/db.php';
+session_start();
+
+if (isset($_SESSION['user_id']) && (time() - ($_SESSION['last_active'] ?? 0) < 1800)) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $stmt = $pdo->prepare('SELECT id, password FROM users WHERE email = ?');
+    $stmt->execute([$_POST['email']]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($user && password_verify($_POST['password'], $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['last_active'] = time();
+        header('Location: dashboard.php');
+        exit;
+    } else {
+        $error = 'Giriş Bilgileri Hatalı';
+    }
+}
+
+$settings = [];
+foreach (['logo','logo_login_width','logo_login_height'] as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt->execute([$k]);
+    $settings[$k] = $stmt->fetchColumn() ?: '';
+}
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Giriş Yap</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap" rel="stylesheet">
+<style>
+body {background: linear-gradient(135deg, #f0f4f8, #d9e2ec); font-family: 'Poppins', sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;}
+.login-box {background: #fff; padding: 40px; border-radius: 16px; box-shadow: 0 10px 40px rgba(0,0,0,0.1); width: 100%; max-width: 400px; text-align: center;}
+.login-logo img {margin-bottom: 20px; width:<?= (int)$settings['logo_login_width'] ?>px; height:<?= (int)$settings['logo_login_height'] ?>px; object-fit:contain;}
+</style>
+</head>
+<body>
+<div class="login-box">
+  <div class="login-logo">
+    <?php if ($settings['logo']): ?><img src="<?= htmlspecialchars($settings['logo']) ?>" alt="Logo"><?php endif; ?>
+  </div>
+  <?php if ($error): ?><div class="alert alert-danger"><?= $error ?></div><?php endif; ?>
+  <form method="post">
+    <div class="mb-3 text-start">
+      <label class="form-label">E-Posta Adresi</label>
+      <input type="email" name="email" class="form-control" required>
+    </div>
+    <div class="mb-3 text-start">
+      <label class="form-label">Şifre</label>
+      <input type="password" name="password" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary w-100">Giriş Yap</button>
+  </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: login.php');
+exit;

--- a/payment_delete.php
+++ b/payment_delete.php
@@ -1,0 +1,11 @@
+<?php
+require __DIR__.'/includes/auth.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT service_id FROM payments WHERE id=?');
+$stmt->execute([$id]);
+$service_id = $stmt->fetchColumn();
+$del = $pdo->prepare('DELETE FROM payments WHERE id=?');
+$del->execute([$id]);
+$redirect = $service_id ? 'service.php?id='.$service_id : 'customers.php';
+header('Location: '.$redirect);
+exit;

--- a/payment_edit.php
+++ b/payment_edit.php
@@ -1,0 +1,44 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM payments WHERE id=?');
+$stmt->execute([$id]);
+$payment = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$payment){
+    header('Location: services.php');
+    exit;
+}
+$usdRate = getUsdRate($pdo);
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $amount = (float)$_POST['amount'];
+    $currency = $_POST['currency'];
+    $amount_try = $currency==='USD' ? $amount*$usdRate : $amount;
+    $stmt = $pdo->prepare('UPDATE payments SET amount_try=?, amount_orig=?, currency=? WHERE id=?');
+    $stmt->execute([$amount_try,$amount,$currency,$id]);
+    $redirect = $payment['service_id'] ? 'service.php?id='.$payment['service_id'] : 'customers.php';
+    header('Location: '.$redirect);
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Tahsilat Düzenle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Tutar</label>
+    <input type="text" name="amount" class="form-control" value="<?= $payment['amount_orig'] ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Para Birimi</label>
+    <select name="currency" class="form-control">
+      <option value="TRY" <?= $payment['currency']=='TRY'?'selected':'' ?>>TL</option>
+      <option value="USD" <?= $payment['currency']=='USD'?'selected':'' ?>>USD</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="<?= $payment['service_id'] ? '/service.php?id='.$payment['service_id'] : '/customers.php' ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/products.php
+++ b/products.php
@@ -1,0 +1,108 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$action = $_GET['action'] ?? '';
+$id = $_GET['id'] ?? null;
+
+if ($action === 'delete' && $id) {
+    $stmt = $pdo->prepare('DELETE FROM products WHERE id=?');
+    $stmt->execute([$id]);
+    header('Location: products.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    $unit = $_POST['unit'];
+    $vat_rate = $_POST['vat_rate'];
+    $price = $_POST['price'];
+    $currency = $_POST['currency'];
+    if ($action === 'edit' && $id) {
+        $stmt = $pdo->prepare('UPDATE products SET name=?, unit=?, vat_rate=?, price=?, currency=? WHERE id=?');
+        $stmt->execute([$name, $unit, $vat_rate, $price, $currency, $id]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO products (name, unit, vat_rate, price, currency) VALUES (?, ?, ?, ?, ?)');
+        $stmt->execute([$name, $unit, $vat_rate, $price, $currency]);
+    }
+    header('Location: products.php');
+    exit;
+}
+
+$edit = null;
+if ($action === 'edit' && $id) {
+    $stmt = $pdo->prepare('SELECT * FROM products WHERE id=?');
+    $stmt->execute([$id]);
+    $edit = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+$products = $pdo->query('SELECT * FROM products ORDER BY id DESC')->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Ürünler</h1>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Ad</th>
+      <th>Birim</th>
+      <th>KDV</th>
+      <th>Fiyat</th>
+      <th>Döviz</th>
+      <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($products as $p): ?>
+    <tr>
+      <td><?= $p['id'] ?></td>
+      <td><?= htmlspecialchars($p['name']) ?></td>
+      <td><?= htmlspecialchars($p['unit']) ?></td>
+      <td><?= $p['vat_rate'] ?></td>
+      <td><?= $p['price'] ?></td>
+      <td><?= htmlspecialchars($p['currency']) ?></td>
+      <td>
+        <a href="products.php?action=edit&id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="products.php?action=delete&id=<?= $p['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?')">Sil</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<hr>
+<h2><?= $edit ? 'Ürünü Düzenle' : 'Yeni Ürün' ?></h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ürün Adı</label>
+    <input type="text" name="name" class="form-control" value="<?= $edit['name'] ?? '' ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Birim</label>
+    <select name="unit" class="form-control">
+      <option value="yıl" <?= isset($edit) && $edit['unit']==='yıl' ? 'selected' : '' ?>>Yıl</option>
+      <option value="ay" <?= isset($edit) && $edit['unit']==='ay' ? 'selected' : '' ?>>Ay</option>
+      <option value="adet" <?= isset($edit) && $edit['unit']==='adet' ? 'selected' : '' ?>>Adet</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">KDV</label>
+    <select name="vat_rate" class="form-control">
+      <option value="0" <?= isset($edit) && $edit['vat_rate']==0 ? 'selected' : '' ?>>Yok</option>
+      <option value="10" <?= isset($edit) && $edit['vat_rate']==10 ? 'selected' : '' ?>>%10</option>
+      <option value="20" <?= isset($edit) && $edit['vat_rate']==20 ? 'selected' : '' ?>>%20</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fiyat</label>
+    <input type="text" name="price" class="form-control" value="<?= $edit['price'] ?? '' ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fiyat Türü</label>
+    <select name="currency" class="form-control">
+      <option value="TRY" <?= isset($edit) && $edit['currency']==='TRY' ? 'selected' : '' ?>>TL</option>
+      <option value="USD" <?= isset($edit) && $edit['currency']==='USD' ? 'selected' : '' ?>>USD</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/provider.php
+++ b/provider.php
@@ -1,0 +1,137 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM providers WHERE id=?');
+$stmt->execute([$id]);
+$provider = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$provider){
+    header('Location: providers.php');
+    exit;
+}
+$usdRate = getUsdRate($pdo);
+$totPurch = (float)$pdo->query("SELECT SUM(price_try) FROM provider_purchases WHERE provider_id={$id}")->fetchColumn();
+$totPay = (float)$pdo->query("SELECT SUM(amount_try) FROM provider_payments WHERE provider_id={$id}")->fetchColumn();
+$balance = $totPurch - $totPay;
+if($balance < 0) $balance = 0;
+if($_SERVER['REQUEST_METHOD']==='POST' && !empty($_POST['item_name'])){
+$ins = $pdo->prepare('INSERT INTO provider_purchases(provider_id,item_name,quantity,unit,unit_price,vat_rate,currency,purchase_date,payment_date,price_try,notes) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+    foreach($_POST['item_name'] as $i=>$name){
+        if(trim($name)=='') continue;
+        $qty = (int)($_POST['quantity'][$i] ?? 1);
+        $unit = $_POST['unit'][$i] ?? '';
+        $price = (float)($_POST['unit_price'][$i] ?? 0);
+        $vat = (float)($_POST['vat_rate'][$i] ?? 0);
+        $cur = $_POST['currency'][$i] ?? 'TRY';
+        $pdate = $_POST['purchase_date'][$i] ?: date('Y-m-d');
+        $paydate = $_POST['payment_date'][$i] ?: $pdate;
+        $line = $qty*$price;
+        $lineVat = $line*$vat/100;
+        $try = $cur==='USD' ? ($line+$lineVat)*$usdRate : ($line+$lineVat);
+        $ins->execute([$id,$name,$qty,$unit,$price,$vat,$cur,$pdate,$paydate,$try,$_POST['notes'][$i] ?? '']);
+    }
+    $_SESSION['message']='Satın alım kaydedildi';
+    header('Location: provider.php?id='.$id);
+    exit;
+}
+$purchasesStmt = $pdo->prepare('SELECT * FROM provider_purchases WHERE provider_id=? ORDER BY purchase_date DESC');
+$purchasesStmt->execute([$id]);
+$purchases = $purchasesStmt->fetchAll(PDO::FETCH_ASSOC);
+$payStmt = $pdo->prepare('SELECT * FROM provider_payments WHERE provider_id=? ORDER BY pay_date DESC');
+$payStmt->execute([$id]);
+$payments = $payStmt->fetchAll(PDO::FETCH_ASSOC);
+include __DIR__.'/includes/header.php';
+?>
+<h1>Tedarikçi: <?= htmlspecialchars($provider['name']) ?><?php if($provider['website']): ?> - <a href="<?= htmlspecialchars($provider['website']) ?>" target="_blank"><?= htmlspecialchars($provider['website']) ?></a><?php endif; ?></h1>
+<p><strong>Bakiye:</strong> <?= number_format($balance,2,',','.') ?> TL</p>
+<a href="provider_payment.php?provider_id=<?= $id ?>" class="btn btn-primary mb-3">Ödeme Yap</a>
+<table class="table table-bordered">
+ <thead>
+  <tr>
+   <th>Ürün</th><th>Miktar</th><th>Birim</th><th>Birim Fiyat</th><th>KDV</th><th>Döviz</th><th>Satın Alma</th><th>Ödeme</th><th>Tutar (TL)</th><th>İşlem</th>
+  </tr>
+ </thead>
+ <tbody>
+  <?php foreach($purchases as $p): ?>
+  <tr>
+   <td><?= htmlspecialchars($p['item_name']) ?></td>
+   <td><?= $p['quantity'] ?></td>
+   <td><?= htmlspecialchars($p['unit']) ?></td>
+   <td><?= number_format($p['unit_price'],2,',','.') ?></td>
+   <td><?= $p['vat_rate'] ?>%</td>
+   <td><?= htmlspecialchars($p['currency']) ?></td>
+   <td><?= date('d.m.Y',strtotime($p['purchase_date'])) ?></td>
+   <td><?= date('d.m.Y',strtotime($p['payment_date'])) ?></td>
+   <td><?= number_format($p['price_try'],2,',','.') ?></td>
+   <td>
+     <a href="purchase_edit.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+     <a href="purchase_delete.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+   </td>
+  </tr>
+  <?php endforeach; ?>
+ </tbody>
+</table>
+<?php if($payments): ?>
+<h2>Ödeme Geçmişi</h2>
+<table class="table table-bordered">
+ <thead><tr><th>Tarih</th><th>Tutar (TL)</th><th>Döviz</th><th>Not</th><th>İşlem</th></tr></thead>
+ <tbody>
+  <?php foreach($payments as $pay): ?>
+  <tr>
+   <td><?= date('d.m.Y',strtotime($pay['pay_date'])) ?></td>
+   <td><?= number_format($pay['amount_try'],2,',','.') ?></td>
+   <td><?= htmlspecialchars($pay['currency']) ?> <?= number_format($pay['amount_orig'],2,',','.') ?></td>
+   <td><?= htmlspecialchars($pay['notes']) ?></td>
+   <td>
+     <a href="provider_payment_edit.php?id=<?= $pay['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+     <a href="provider_payment_delete.php?id=<?= $pay['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+   </td>
+  </tr>
+  <?php endforeach; ?>
+ </tbody>
+</table>
+<?php endif; ?>
+<hr>
+<h2>Yeni Satın Alım</h2>
+<form method="post">
+<table class="table" id="items">
+ <thead>
+  <tr><th>Ürün</th><th>Miktar</th><th>Birim</th><th>Birim Fiyat</th><th>KDV</th><th>Döviz</th><th>Satın Alma Tarihi</th><th>Ödeme Tarihi</th><th>Not</th><th></th></tr>
+ </thead>
+ <tbody></tbody>
+</table>
+<button type="button" class="btn btn-secondary mb-3" id="addRow">Satır Ekle</button>
+<button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<script>
+function addRow(){
+  var tr=document.createElement('tr');
+  tr.innerHTML='<td><input type="text" name="item_name[]" class="form-control" required></td>'+
+    '<td><input type="number" name="quantity[]" value="1" class="form-control"></td>'+
+    '<td><select name="unit[]" class="form-control"><option value="ADET">ADET</option><option value="AY">AY</option><option value="YIL">YIL</option></select></td>'+
+    '<td><input type="text" name="unit_price[]" class="form-control"></td>'+
+    '<td><select name="vat_rate[]" class="form-control"><option value="0">%0</option><option value="10">%10</option><option value="20">%20</option></select></td>'+
+    '<td><select name="currency[]" class="form-control"><option value="TRY">TRY</option><option value="USD">USD</option></select></td>'+
+    '<td><input type="date" name="purchase_date[]" class="form-control" value="<?= date("Y-m-d") ?>"></td>'+
+    '<td><input type="date" name="payment_date[]" class="form-control"></td>'+
+    '<td><input type="text" name="notes[]" class="form-control"></td>'+
+    '<td><button type="button" class="btn btn-sm btn-danger" onclick="this.closest(\'tr\').remove();">X</button><br><small class="price-info text-muted"></small></td>';
+  tr.querySelectorAll('input,select').forEach(function(el){el.addEventListener('input',function(){updateRow(tr);});});
+  updateRow(tr);
+  document.querySelector('#items tbody').appendChild(tr);
+}
+function updateRow(tr){
+  var qty=parseFloat(tr.querySelector('[name="quantity[]"]').value)||1;
+  var price=parseFloat(tr.querySelector('[name="unit_price[]"]').value)||0;
+  var vat=parseFloat(tr.querySelector('[name="vat_rate[]"]').value)||0;
+  var cur=tr.querySelector('[name="currency[]"]').value;
+  var rate=cur==='USD'?<?= $usdRate ?>:1;
+  var subtotal=qty*price*rate;
+  var vatTl=subtotal*vat/100;
+  var total=subtotal+vatTl;
+  tr.querySelector('.price-info').textContent='Birim: '+(price*rate).toFixed(2)+' TL, KDV: '+vatTl.toFixed(2)+' TL, Toplam: '+total.toFixed(2)+' TL';
+}
+addRow();
+document.getElementById('addRow').addEventListener('click',addRow);
+</script>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/provider_payment.php
+++ b/provider_payment.php
@@ -1,0 +1,59 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$provider_id = isset($_GET['provider_id']) ? (int)$_GET['provider_id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM providers WHERE id=?');
+$stmt->execute([$provider_id]);
+$provider = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$provider){
+    header('Location: providers.php');
+    exit;
+}
+$usdRate = getUsdRate($pdo);
+$totPurch = (float)$pdo->query("SELECT SUM(price_try) FROM provider_purchases WHERE provider_id={$provider_id}")->fetchColumn();
+$totPay = (float)$pdo->query("SELECT SUM(amount_try) FROM provider_payments WHERE provider_id={$provider_id}")->fetchColumn();
+$balance = $totPurch - $totPay;
+if($balance < 0) $balance = 0;
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $amount = (float)$_POST['amount'];
+    $currency = $_POST['currency'];
+    $pay_date = $_POST['pay_date'] ?: date('Y-m-d');
+    $notes = $_POST['notes'] ?? '';
+    $amount_try = $currency==='USD' ? $amount * $usdRate : $amount;
+    $stmt = $pdo->prepare('INSERT INTO provider_payments(provider_id,amount_try,amount_orig,currency,pay_date,notes) VALUES (?,?,?,?,?,?)');
+    $stmt->execute([$provider_id,$amount_try,$amount,$currency,$pay_date,$notes]);
+    $_SESSION['message'] = 'Ödeme kaydedildi';
+    header('Location: provider.php?id='.$provider_id);
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Tedarikçi Ödeme - <?= htmlspecialchars($provider['name']) ?></h1>
+<p><strong>Kalan Borç:</strong> <?= number_format($balance,2,',','.') ?> TL</p>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Tutar</label>
+    <input type="text" name="amount" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Para Birimi</label>
+    <select name="currency" class="form-control">
+      <option value="TRY">TL</option>
+      <option value="USD">USD</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ödeme Tarihi</label>
+    <input type="date" name="pay_date" class="form-control" value="<?= date('Y-m-d') ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not</label>
+    <input type="text" name="notes" class="form-control">
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="provider.php?id=<?= $provider_id ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/provider_payment_delete.php
+++ b/provider_payment_delete.php
@@ -1,0 +1,10 @@
+<?php
+require __DIR__.'/includes/auth.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT provider_id FROM provider_payments WHERE id=?');
+$stmt->execute([$id]);
+$provider_id = $stmt->fetchColumn();
+$pdo->prepare('DELETE FROM provider_payments WHERE id=?')->execute([$id]);
+header('Location: provider.php?id='.$provider_id);
+exit;

--- a/provider_payment_edit.php
+++ b/provider_payment_edit.php
@@ -1,0 +1,55 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM provider_payments WHERE id=?');
+$stmt->execute([$id]);
+$payment = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$payment){
+    header('Location: providers.php');
+    exit;
+}
+$provider_id = $payment['provider_id'];
+$usdRate = getUsdRate($pdo);
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $amount = (float)$_POST['amount'];
+    $currency = $_POST['currency'];
+    $pay_date = $_POST['pay_date'] ?: date('Y-m-d');
+    $notes = $_POST['notes'] ?? '';
+    $amount_try = $currency==='USD' ? $amount*$usdRate : $amount;
+    $upd = $pdo->prepare('UPDATE provider_payments SET amount_try=?, amount_orig=?, currency=?, pay_date=?, notes=? WHERE id=?');
+    $upd->execute([$amount_try,$amount,$currency,$pay_date,$notes,$id]);
+    $_SESSION['message'] = 'Ödeme güncellendi';
+    header('Location: provider.php?id='.$provider_id);
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Ödeme Düzenle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Tutar</label>
+    <input type="text" name="amount" class="form-control" value="<?= $payment['amount_orig'] ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Para Birimi</label>
+    <select name="currency" class="form-control">
+      <option value="TRY" <?= $payment['currency']=='TRY'?'selected':'' ?>>TL</option>
+      <option value="USD" <?= $payment['currency']=='USD'?'selected':'' ?>>USD</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ödeme Tarihi</label>
+    <input type="date" name="pay_date" class="form-control" value="<?= htmlspecialchars($payment['pay_date']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not</label>
+    <input type="text" name="notes" class="form-control" value="<?= htmlspecialchars($payment['notes']) ?>">
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="provider.php?id=<?= $provider_id ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/providers.php
+++ b/providers.php
@@ -1,0 +1,80 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$action = $_GET['action'] ?? '';
+$id = $_GET['id'] ?? null;
+
+if ($action === 'delete' && $id) {
+    $stmt = $pdo->prepare('DELETE FROM providers WHERE id=?');
+    $stmt->execute([$id]);
+    header('Location: providers.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    $website = $_POST['website'];
+    if ($action === 'edit' && $id) {
+        $stmt = $pdo->prepare('UPDATE providers SET name=?, website=? WHERE id=?');
+        $stmt->execute([$name, $website, $id]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO providers (name, website) VALUES (?, ?)');
+        $stmt->execute([$name, $website]);
+    }
+    header('Location: providers.php');
+    exit;
+}
+
+$edit = null;
+if ($action === 'edit' && $id) {
+    $stmt = $pdo->prepare('SELECT * FROM providers WHERE id=?');
+    $stmt->execute([$id]);
+    $edit = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+$stmt = $pdo->query('SELECT p.*, (SELECT IFNULL(SUM(price_try),0) FROM provider_purchases WHERE provider_id=p.id) - (SELECT IFNULL(SUM(amount_try),0) FROM provider_payments WHERE provider_id=p.id) AS total_due FROM providers p ORDER BY p.id DESC');
+$providers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Sağlayıcılar</h1>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Ad</th>
+      <th>Web Sitesi</th>
+      <th>Borç (TL)</th>
+      <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($providers as $p): ?>
+    <tr>
+      <td><?= $p['id'] ?></td>
+      <td><a href="provider.php?id=<?= $p['id'] ?>"><?= htmlspecialchars($p['name']) ?></a></td>
+      <td><?= htmlspecialchars($p['website']) ?></td>
+      <td><?= number_format($p['total_due'] ?? 0, 2, ',', '.') ?></td>
+      <td>
+        <a href="providers.php?action=edit&id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="provider_payment.php?provider_id=<?= $p['id'] ?>" class="btn btn-sm btn-primary">Ödeme Yap</a>
+        <a href="providers.php?action=delete&id=<?= $p['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?')">Sil</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<hr>
+<h2><?= $edit ? 'Sağlayıcıyı Düzenle' : 'Yeni Sağlayıcı' ?></h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ad</label>
+    <input type="text" name="name" class="form-control" value="<?= $edit['name'] ?? '' ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Web Sitesi</label>
+    <input type="text" name="website" class="form-control" value="<?= $edit['website'] ?? '' ?>">
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/purchase_add.php
+++ b/purchase_add.php
@@ -1,0 +1,83 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$providers = $pdo->query('SELECT id,name FROM providers ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$usdRate = getUsdRate($pdo);
+
+if($_SERVER['REQUEST_METHOD']==='POST' && !empty($_POST['provider_id']) && !empty($_POST['item_name'])){
+    $providerId = (int)$_POST['provider_id'];
+    $ins = $pdo->prepare('INSERT INTO provider_purchases(provider_id,item_name,quantity,unit,unit_price,vat_rate,currency,purchase_date,payment_date,price_try,notes) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+    foreach($_POST['item_name'] as $i=>$name){
+        if(trim($name)=='') continue;
+        $qty = (int)($_POST['quantity'][$i] ?? 1);
+        $unit = $_POST['unit'][$i] ?? '';
+        $price = (float)($_POST['unit_price'][$i] ?? 0);
+        $vat = (float)($_POST['vat_rate'][$i] ?? 0);
+        $cur = $_POST['currency'][$i] ?? 'TRY';
+        $pdate = $_POST['purchase_date'][$i] ?: date('Y-m-d');
+        $paydate = $_POST['payment_date'][$i] ?: $pdate;
+        $line = $qty*$price;
+        $lineVat = $line*$vat/100;
+        $try = $cur==='USD' ? ($line+$lineVat)*$usdRate : ($line+$lineVat);
+        $ins->execute([$providerId,$name,$qty,$unit,$price,$vat,$cur,$pdate,$paydate,$try,$_POST['notes'][$i] ?? '']);
+    }
+    $_SESSION['message'] = 'Satın alım kaydedildi';
+    header('Location: providers.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Ürün Satın Al</h1>
+<form method="post">
+<div class="mb-3">
+ <label class="form-label">Sağlayıcı</label>
+ <select name="provider_id" class="form-control" required>
+  <option value="">Seçiniz</option>
+  <?php foreach($providers as $pr): ?>
+   <option value="<?= $pr['id'] ?>"><?= htmlspecialchars($pr['name']) ?></option>
+  <?php endforeach; ?>
+ </select>
+</div>
+<table class="table" id="items">
+ <thead>
+  <tr><th>Ürün</th><th>Miktar</th><th>Birim</th><th>Birim Fiyat</th><th>KDV</th><th>Döviz</th><th>Satın Alma</th><th>Ödeme</th><th>Not</th><th></th></tr>
+ </thead>
+ <tbody></tbody>
+</table>
+<button type="button" class="btn btn-secondary mb-3" id="addRow">Satır Ekle</button>
+<button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<script>
+function addRow(){
+  var tr=document.createElement('tr');
+  tr.innerHTML='<td><input type="text" name="item_name[]" class="form-control" required></td>'+
+    '<td><input type="number" name="quantity[]" value="1" class="form-control"></td>'+
+    '<td><select name="unit[]" class="form-control"><option value="ADET">ADET</option><option value="AY">AY</option><option value="YIL">YIL</option></select></td>'+
+    '<td><input type="text" name="unit_price[]" class="form-control"></td>'+
+    '<td><select name="vat_rate[]" class="form-control"><option value="0">%0</option><option value="10">%10</option><option value="20">%20</option></select></td>'+
+    '<td><select name="currency[]" class="form-control"><option value="TRY">TRY</option><option value="USD">USD</option></select></td>'+
+    '<td><input type="date" name="purchase_date[]" class="form-control" value="<?= date("Y-m-d") ?>"></td>'+
+    '<td><input type="date" name="payment_date[]" class="form-control"></td>'+
+    '<td><input type="text" name="notes[]" class="form-control"></td>'+
+    '<td><button type="button" class="btn btn-sm btn-danger" onclick="this.closest(\'tr\').remove();">X</button><br><small class="price-info text-muted"></small></td>';
+  tr.querySelectorAll('input,select').forEach(function(el){el.addEventListener('input',function(){updateRow(tr);});});
+  updateRow(tr);
+  document.querySelector('#items tbody').appendChild(tr);
+}
+function updateRow(tr){
+  var qty=parseFloat(tr.querySelector('[name="quantity[]"]').value)||1;
+  var price=parseFloat(tr.querySelector('[name="unit_price[]"]').value)||0;
+  var vat=parseFloat(tr.querySelector('[name="vat_rate[]"]').value)||0;
+  var cur=tr.querySelector('[name="currency[]"]').value;
+  var rate=cur==='USD'?<?= $usdRate ?>:1;
+  var subtotal=qty*price*rate;
+  var vatTl=subtotal*vat/100;
+  var total=subtotal+vatTl;
+  tr.querySelector('.price-info').textContent='Birim: '+(price*rate).toFixed(2)+' TL, KDV: '+vatTl.toFixed(2)+' TL, Toplam: '+total.toFixed(2)+' TL';
+}
+addRow();
+document.getElementById('addRow').addEventListener('click',addRow);
+</script>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/purchase_delete.php
+++ b/purchase_delete.php
@@ -1,0 +1,14 @@
+<?php
+require __DIR__.'/includes/auth.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT provider_id FROM provider_purchases WHERE id=?');
+$stmt->execute([$id]);
+$provider_id = $stmt->fetchColumn();
+if($provider_id){
+    $del = $pdo->prepare('DELETE FROM provider_purchases WHERE id=?');
+    $del->execute([$id]);
+    $_SESSION['message']='Satın alım silindi';
+    header('Location: provider.php?id='.$provider_id);
+    exit;
+}
+header('Location: providers.php');

--- a/purchase_edit.php
+++ b/purchase_edit.php
@@ -1,0 +1,69 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT pp.*, pr.name AS provider_name FROM provider_purchases pp JOIN providers pr ON pp.provider_id=pr.id WHERE pp.id=?');
+$stmt->execute([$id]);
+$purchase = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$purchase){
+    header('Location: providers.php');
+    exit;
+}
+$provider_id = $purchase['provider_id'];
+$usdRate = getUsdRate($pdo);
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $name = $_POST['item_name'];
+    $qty = (int)$_POST['quantity'];
+    $unit = $_POST['unit'];
+    $price = (float)$_POST['unit_price'];
+    $vat = (float)$_POST['vat_rate'];
+    $cur = $_POST['currency'];
+    $pdate = $_POST['purchase_date'];
+    $paydate = $_POST['payment_date'];
+    $notes = $_POST['notes'];
+    $line = $qty*$price;
+    $lineVat = $line*$vat/100;
+    $try = $cur==='USD' ? ($line+$lineVat)*$usdRate : ($line+$lineVat);
+    $stmt = $pdo->prepare('UPDATE provider_purchases SET item_name=?,quantity=?,unit=?,unit_price=?,vat_rate=?,currency=?,purchase_date=?,payment_date=?,price_try=?,notes=? WHERE id=?');
+    $stmt->execute([$name,$qty,$unit,$price,$vat,$cur,$pdate,$paydate,$try,$notes,$id]);
+    $_SESSION['message']='Satın alım güncellendi';
+    header('Location: provider.php?id='.$provider_id);
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Satın Alım Düzenle - <?= htmlspecialchars($purchase['provider_name']) ?></h1>
+<form method="post">
+  <div class="mb-3"><label class="form-label">Ürün</label><input type="text" name="item_name" class="form-control" value="<?= htmlspecialchars($purchase['item_name']) ?>" required></div>
+  <div class="mb-3"><label class="form-label">Miktar</label><input type="number" name="quantity" value="<?= $purchase['quantity'] ?>" class="form-control"></div>
+  <div class="mb-3"><label class="form-label">Birim</label>
+    <select name="unit" class="form-control">
+      <option value="ADET" <?= $purchase['unit']=='ADET'?'selected':'' ?>>ADET</option>
+      <option value="AY" <?= $purchase['unit']=='AY'?'selected':'' ?>>AY</option>
+      <option value="YIL" <?= $purchase['unit']=='YIL'?'selected':'' ?>>YIL</option>
+    </select>
+  </div>
+  <div class="mb-3"><label class="form-label">Birim Fiyat</label><input type="text" name="unit_price" value="<?= $purchase['unit_price'] ?>" class="form-control"></div>
+  <div class="mb-3"><label class="form-label">KDV</label>
+    <select name="vat_rate" class="form-control">
+      <option value="0" <?= $purchase['vat_rate']==0?'selected':'' ?>>%0</option>
+      <option value="10" <?= $purchase['vat_rate']==10?'selected':'' ?>>%10</option>
+      <option value="20" <?= $purchase['vat_rate']==20?'selected':'' ?>>%20</option>
+    </select>
+  </div>
+  <div class="mb-3"><label class="form-label">Döviz</label>
+    <select name="currency" class="form-control">
+      <option value="TRY" <?= $purchase['currency']=='TRY'?'selected':'' ?>>TRY</option>
+      <option value="USD" <?= $purchase['currency']=='USD'?'selected':'' ?>>USD</option>
+    </select>
+  </div>
+  <div class="mb-3"><label class="form-label">Satın Alma Tarihi</label><input type="date" name="purchase_date" value="<?= $purchase['purchase_date'] ?>" class="form-control"></div>
+  <div class="mb-3"><label class="form-label">Ödeme Tarihi</label><input type="date" name="payment_date" value="<?= $purchase['payment_date'] ?>" class="form-control"></div>
+  <div class="mb-3"><label class="form-label">Not</label><input type="text" name="notes" value="<?= htmlspecialchars($purchase['notes']) ?>" class="form-control"></div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="provider.php?id=<?= $provider_id ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/reminder_cron.php
+++ b/reminder_cron.php
@@ -1,0 +1,17 @@
+<?php
+require __DIR__.'/includes/db.php';
+require __DIR__.'/includes/functions.php';
+$date = date('Y-m-d');
+$stmt=$pdo->query("SELECT s.id,s.due_date,s.reminder_days,c.id AS cid,c.full_name,c.email,s.site_name FROM services s JOIN customers c ON s.customer_id=c.id WHERE s.reminder_enabled=1");
+$admins=$pdo->query("SELECT email FROM users")->fetchAll(PDO::FETCH_COLUMN);
+foreach($stmt->fetchAll(PDO::FETCH_ASSOC) as $svc){
+    $days=(strtotime($svc['due_date'])-strtotime($date))/86400;
+    $sel=array_filter(array_map('intval',explode(',',$svc['reminder_days'])));
+    if(in_array($days,$sel)){
+        $err='';
+        $subject='Ödeme Hatırlatma';
+        $body="Sayın {$svc['full_name']},<br><br>{$svc['site_name']} hizmetinizin bitiş tarihi yaklaşmaktadır. Bitiş tarihi: ".date('d.m.Y',strtotime($svc['due_date'])).".<br><br>Hizmet süresini uzatmak veya ödeme yapmak için lütfen bizimle iletişime geçin.";
+        sendMail($pdo,$svc['email'],$subject,$body,$err,$svc['id'],$svc['cid']);
+        foreach($admins as $a){sendMail($pdo,$a,$subject,$body,$err,$svc['id'],$svc['cid']);}
+    }
+}

--- a/send_reminder.php
+++ b/send_reminder.php
@@ -1,0 +1,63 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+$id = isset($_GET['service_id']) ? (int)$_GET['service_id'] : 0;
+$stmt = $pdo->prepare("SELECT s.id,s.site_name,s.due_date,c.id AS cid,c.full_name,c.email FROM services s JOIN customers c ON s.customer_id=c.id WHERE s.id=?");
+$stmt->execute([$id]);
+$svc = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$svc){
+    header('Location: services.php');
+    exit;
+}
+$usdRate = getUsdRate($pdo);
+$itemsStmt = $pdo->prepare('SELECT * FROM service_items WHERE service_id=?');
+$itemsStmt->execute([$svc['id']]);
+$rows='';
+$total=0; $vatT=0;
+foreach($itemsStmt->fetchAll(PDO::FETCH_ASSOC) as $it){
+    $sub=$it['unit_price']*$it['quantity'];
+    $vat=$sub*$it['vat_rate']/100;
+    $ttl=$sub+$vat;
+    if($it['currency']==='USD'){ $sub*=$usdRate; $vat*=$usdRate; $ttl*=$usdRate; }
+    $total+=$sub; $vatT+=$vat;
+    $rows.='<tr><td>'.htmlspecialchars($it['item_name']).'</td><td>'.$it['quantity'].' '.htmlspecialchars($it['unit']).'</td><td>'.number_format($it['unit_price'],2,',','.').'</td><td>'.$it['vat_rate'].'%</td><td>'.number_format($vat,2,',','.').'</td><td>'.number_format($ttl,2,',','.').'</td><td>'.htmlspecialchars($svc['site_name']).'</td></tr>';
+}
+$grand=$total+$vatT;
+$settings=getEmailSettings($pdo);
+$subject = 'Ödeme Hatırlatma';
+$body = "Sayın {$svc['full_name']},<br><br>{$svc['site_name']} hizmetinizin bitiş tarihi yaklaşmaktadır. Bitiş tarihi: ".date('d.m.Y',strtotime($svc['due_date'])).".<br><br>";
+$body .= '<table border="1" cellpadding="5" style="border-collapse:collapse">';
+$body .= '<tr><th>Hizmet</th><th>Süre</th><th>Birim Fiyat</th><th>KDV Oranı</th><th>KDV Tutarı</th><th>Toplam</th><th>Site</th></tr>'.$rows.'</table>';
+$body .= '<br><strong>Birim Fiyatı:</strong> '.number_format($total,2,',','.').' TL<br>';
+$body .= '<strong>KDV Tutarı:</strong> '.number_format($vatT,2,',','.').' TL<br>';
+$body .= '<strong>Genel Toplam:</strong> '.number_format($grand,2,',','.').' TL<br><br>';
+$body .= 'Hizmet süresini uzatmak veya ödeme yapmak için lütfen bizimle iletişime geçin.<br><br>Saygılarımızla,<br>'.$settings['from_name'];
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $subject=$_POST['subject'];
+    $body=$_POST['body'];
+    $err='';
+    sendMail($pdo,$svc['email'],$subject,$body,$err,$svc['id'],$svc['cid']);
+    $admins=$pdo->query("SELECT email FROM users")->fetchAll(PDO::FETCH_COLUMN);
+    foreach($admins as $ad){sendMail($pdo,$ad,$subject,$body,$err,$svc['id'],$svc['cid']);}
+    $_SESSION['message']=$err?'Hatırlatma gönderilemedi: '.$err:'Hatırlatma gönderildi';
+    header('Location: service.php?id='.$id);
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hatırlatma Maili Gönder</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Konu</label>
+    <input type="text" name="subject" class="form-control" value="<?= htmlspecialchars($subject) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">İçerik</label>
+    <textarea name="body" rows="10" class="form-control"><?= htmlspecialchars($body) ?></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Gönder</button>
+  <a href="service.php?id=<?= $svc['id'] ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/service.php
+++ b/service.php
@@ -1,0 +1,86 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT s.*, c.full_name, c.email, c.phone, c.company, c.address FROM services s JOIN customers c ON s.customer_id=c.id WHERE s.id=?');
+$stmt->execute([$id]);
+$service = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$service){
+    header('Location: services.php');
+    exit;
+}
+$usdRate = getUsdRate($pdo);
+$itemStmt = $pdo->prepare('SELECT si.*, pr.name AS provider_name FROM service_items si LEFT JOIN providers pr ON si.provider_id=pr.id WHERE si.service_id=?');
+$itemStmt->execute([$service['id']]);
+$items = $itemStmt->fetchAll(PDO::FETCH_ASSOC);
+$total = 0; $vatT=0;
+foreach($items as $it){
+    $line = $it['quantity']*$it['unit_price'];
+    $lineVat = $line*$it['vat_rate']/100;
+    if($it['currency']==='USD'){$line*=$usdRate; $lineVat*=$usdRate;}
+    $total += $line; $vatT += $lineVat;
+}
+$grand = $total + $vatT;
+$days = (strtotime($service['due_date']) - time())/86400;
+$badge='success';
+if($days<=30) $badge='info';
+if($days<=14) $badge='warning';
+if($days<0) $badge='danger';
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hizmet Detayı</h1>
+<div class="row">
+ <div class="col-md-8">
+  <table class="table table-bordered">
+   <tr><th>Müşteri</th><td><?= htmlspecialchars($service['full_name']) ?></td></tr>
+   <tr><th>E-posta</th><td><?= htmlspecialchars($service['email']) ?></td></tr>
+   <tr><th>Telefon</th><td><?= htmlspecialchars($service['phone']) ?></td></tr>
+   <tr><th>Şirket</th><td><?= htmlspecialchars($service['company']) ?></td></tr>
+  <tr><th>Site</th><td><?= htmlspecialchars($service['site_name']) ?></td></tr>
+  <tr><th>Hizmet Türü</th><td><?= htmlspecialchars($service['service_type']) ?></td></tr>
+  <tr><th>Başlangıç Tarihi</th><td><?= date('d.m.Y',strtotime($service['start_date'])) ?></td></tr>
+   <tr><th>Ödeme Tarihi</th><td><?= date('d.m.Y',strtotime($service['due_date'])) ?></td></tr>
+   <tr><th>Durum</th><td><?= htmlspecialchars($service['status']) ?></td></tr>
+   <tr><th>Not</th><td><?= nl2br(htmlspecialchars($service['notes'])) ?></td></tr>
+  </table>
+ </div>
+ <div class="col-md-4 d-flex align-items-center justify-content-center">
+  <span class="badge bg-<?= $badge ?> fs-4"><?= ($days>=0?'+':'').(int)$days ?> gün</span>
+ </div>
+</div>
+<?php if($items): ?>
+<h2>Hizmet / Ürün Detayı</h2>
+<table class="table table-bordered">
+ <thead>
+  <tr>
+   <th>Ad</th><th>Miktar</th><th>Birim</th><th>Birim Fiyat</th><th>Döviz</th><th>Sağlayıcı</th><th>KDV</th><th>Açıklama</th><th>Toplam (TL)</th>
+  </tr>
+ </thead>
+ <tbody>
+  <?php foreach($items as $it): ?>
+  <?php $sub=$it['quantity']*$it['unit_price'];$vat=$sub*$it['vat_rate']/100;$line=$it['currency']=='USD'?($sub+$vat)*$usdRate:($sub+$vat); ?>
+  <tr>
+   <td><?= htmlspecialchars($it['item_name']) ?></td>
+   <td><?= $it['quantity'] ?></td>
+   <td><?= htmlspecialchars($it['unit']) ?></td>
+   <td><?= number_format($it['unit_price'],2,',','.') ?></td>
+   <td><?= htmlspecialchars($it['currency']) ?></td>
+   <td><?= htmlspecialchars($it['provider_name']) ?></td>
+   <td><?= $it['vat_rate'] ?>%</td>
+   <td><?= htmlspecialchars($it['description']) ?></td>
+   <td><?= number_format($line,2,',','.') ?></td>
+  </tr>
+  <?php endforeach; ?>
+ </tbody>
+</table>
+<?php endif; ?>
+<div class="text-end">
+ <strong>Birim Fiyatı: <?= number_format($total,2,',','.') ?> TL</strong><br>
+ <strong>KDV Tutarı: <?= number_format($vatT,2,',','.') ?> TL</strong><br>
+ <strong>Genel Toplam: <?= number_format($grand,2,',','.') ?> TL</strong>
+</div>
+<a href="service_payment.php?service_id=<?= $service['id'] ?>" class="btn btn-primary">Tahsilat Yap</a>
+<a href="send_reminder.php?service_id=<?= $service['id'] ?>" class="btn btn-info">Hatırlatma Maili Gönder</a>
+<a href="service_edit.php?id=<?= $service['id'] ?>" class="btn btn-warning">Düzenle</a>
+<a href="service_delete.php?id=<?= $service['id'] ?>" class="btn btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/service_add.php
+++ b/service_add.php
@@ -1,0 +1,273 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+$customers = $pdo->query("SELECT id, full_name FROM customers")->fetchAll(PDO::FETCH_ASSOC);
+$products = $pdo->query("SELECT id, name, price, currency, vat_rate FROM products")->fetchAll(PDO::FETCH_ASSOC);
+$providers = $pdo->query("SELECT id, name FROM providers")->fetchAll(PDO::FETCH_ASSOC);
+$usdRate = getUsdRate($pdo);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $start = $_POST['start_date'];
+    $due = $_POST['due_date'] ?: date('Y-m-d', strtotime($start.' +1 year'));
+    $duration = (int)((strtotime($due) - strtotime($start)) / 86400);
+    $remEnabled = isset($_POST['reminder_enabled']) ? 1 : 0;
+    $remDays = $remEnabled && !empty($_POST['reminder_days']) ? implode(',', $_POST['reminder_days']) : '';
+
+    $totalTry = 0;
+    if(!empty($_POST['item_name'])){
+        foreach($_POST['item_name'] as $i => $name){
+            $qty = (float)($_POST['quantity'][$i] ?? 1);
+            $price = (float)($_POST['unit_price'][$i] ?? 0);
+            $vat = (float)($_POST['item_vat'][$i] ?? 0);
+            $cur = $_POST['item_currency'][$i] ?? 'TRY';
+            $line = $qty * $price;
+            $lineVat = $line * $vat / 100;
+            $lineTl = $cur==='USD' ? ($line + $lineVat) * $usdRate : ($line + $lineVat);
+            $totalTry += $lineTl;
+        }
+    }
+
+    $stmt = $pdo->prepare("INSERT INTO services (customer_id, product_id, provider_id, site_name, service_type, start_date, due_date, duration, unit, price, currency, vat_rate, price_try, status, notes, reminder_enabled, reminder_days, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'gün', ?, 'TRY', 0, ?, ?, ?, ?, ?, NOW())");
+    $stmt->execute([
+        $_POST['customer_id'],
+        null,
+        null,
+        $_POST['site_name'],
+        $_POST['service_type'],
+        $start,
+        $due,
+        $duration,
+        $totalTry,
+        $totalTry,
+        $_POST['status'],
+        $_POST['notes'],
+        $remEnabled,
+        $remDays
+    ]);
+    $serviceId = $pdo->lastInsertId();
+    if(!empty($_POST['item_name'])){
+        $itemStmt = $pdo->prepare('INSERT INTO service_items (service_id,item_name,quantity,unit,unit_price,vat_rate,currency,provider_id,description) VALUES (?,?,?,?,?,?,?,?,?)');
+        foreach($_POST['item_name'] as $i => $n){
+            $name = $n==='__new__' ? ($_POST['item_custom'][$i] ?? '') : $n;
+            if(trim($name)==='') continue;
+            $itemStmt->execute([
+                $serviceId,
+                $name,
+                (int)($_POST['quantity'][$i] ?? 1),
+                $_POST['unit'][$i] ?? '',
+                (float)($_POST['unit_price'][$i] ?? 0),
+                (float)($_POST['item_vat'][$i] ?? 0),
+                $_POST['item_currency'][$i] ?? 'TRY',
+                ($_POST['provider_item'][$i] ?? '') ?: null,
+                $_POST['description'][$i] ?? ''
+            ]);
+        }
+    }
+    if(!empty($_POST['new_products_json'])){
+        $new = json_decode($_POST['new_products_json'], true) ?: [];
+        $prodStmt = $pdo->prepare('INSERT INTO products(name,unit,vat_rate,price,currency) VALUES (?,?,?,?,?)');
+        foreach($new as $p){
+            $prodStmt->execute([$p['name'],$p['unit'],$p['vat_rate'],$p['price'],$p['currency']]);
+        }
+    }
+    header('Location: services.php');
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hizmet Ekle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Müşteri</label>
+    <select name="customer_id" class="form-control" required>
+      <?php foreach ($customers as $c): ?>
+      <option value="<?= $c['id'] ?>"><?= htmlspecialchars($c['full_name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Hizmet Türü</label>
+    <input type="text" name="service_type" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Site / Alan Adı</label>
+    <input type="text" name="site_name" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Başlangıç Tarihi</label>
+    <input type="date" name="start_date" id="start" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ödeme Tarihi</label>
+    <input type="date" name="due_date" id="due" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Durum</label>
+    <select name="status" class="form-control">
+      <option value="aktif">Aktif</option>
+      <option value="pasif">Pasif</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not</label>
+    <textarea name="notes" class="form-control"></textarea>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="reminder" name="reminder_enabled" value="1">
+    <label class="form-check-label" for="reminder">Mail ile hatırlatma gönderilsin mi?</label>
+  </div>
+  <div id="reminder_opts" class="mb-3 d-none">
+    <label class="form-label">Gönderim Günleri</label><br>
+    <?php foreach([30,15,7,0] as $d): ?>
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="checkbox" name="reminder_days[]" value="<?= $d ?>">
+      <label class="form-check-label"><?= $d==0?'Son gün':$d.' gün önce' ?></label>
+    </div>
+    <?php endforeach; ?>
+  </div>
+
+  <h3>Hizmet / Ürün Detayı</h3>
+  <table class="table" id="items">
+    <thead>
+      <tr>
+        <th>Hizmet / Ürün</th>
+        <th>Miktar</th>
+        <th>Birim</th>
+        <th>Birim Fiyat</th>
+        <th>Döviz</th>
+        <th>Sağlayıcı</th>
+        <th>KDV</th>
+        <th>Açıklama</th>
+        <th>Toplam</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <button type="button" class="btn btn-secondary mb-3" id="addRow">Satır Ekle</button>
+
+  <div class="mb-3 text-end">
+    <strong>Toplam Tutar (TL): <span id="total">0</span></strong><br>
+    <strong>KDV Tutarı (TL): <span id="vat_t">0</span></strong><br>
+    <strong>Güncel Kur: <span id="rate"><?= number_format($usdRate,2,',','.') ?></span></strong><br>
+    <strong>Genel Toplam (TL): <span id="grand">0</span></strong>
+  </div>
+  <input type="hidden" name="new_products_json" id="new_products_json">
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<script>
+var productOptions = '<?php foreach($products as $p){echo "<option value=\"".$p['name']."\" data-price=\"{$p['price']}\" data-currency=\"{$p['currency']}\" data-vat=\"{$p['vat_rate']}\">".htmlspecialchars($p['name'])."</option>";} ?>' + '<option value="__new__">+ Özel Ürün</option>';
+var providerOptions = '<?php foreach($providers as $p){echo "<option value=\"{$p['id']}\">".htmlspecialchars($p['name'])."</option>";} ?>';
+var newProducts = [];
+function addRow(){
+  var tbody=document.querySelector('#items tbody');
+  var tr=document.createElement('tr');
+  tr.innerHTML='<td><select name="item_name[]" class="form-control prod"><option value="">Seçiniz</option>'+productOptions+'</select><input type="text" name="item_custom[]" class="form-control mt-2 d-none custom" placeholder="Ürün adı"></td>'+
+    '<td><input type="number" name="quantity[]" value="1" class="form-control qty"></td>'+
+    '<td><select name="unit[]" class="form-control unit">'+
+      '<option value="adet">Adet</option><option value="ay">Ay</option><option value="yıl">Yıl</option>'+
+    '</select></td>'+
+    '<td><input type="text" name="unit_price[]" class="form-control price"></td>'+
+    '<td><select name="item_currency[]" class="form-control row-currency"><option value="TRY">TRY</option><option value="USD">USD</option></select></td>'+
+    '<td><select name="provider_item[]" class="form-control provider"><option value="">Seçiniz</option>'+providerOptions+'</select></td>'+
+    '<td><select name="item_vat[]" class="form-control vat">'+
+       '<option value="0">%0</option><option value="1">%1</option><option value="10">%10</option><option value="20">%20</option>'+
+    '</select></td>'+
+    '<td><input type="text" name="description[]" class="form-control desc"></td>'+
+    '<td class="row-total">0</td>'+
+    '<td><button type="button" class="btn btn-sm btn-danger remove-row">X</button></td>';
+  tbody.appendChild(tr);
+  tr.querySelector('.remove-row').addEventListener('click',function(){tr.remove();updateTotal();});
+  ['input','change'].forEach(function(ev){
+     tr.querySelector('.qty').addEventListener(ev,updateTotal);
+     tr.querySelector('.price').addEventListener(ev,updateTotal);
+     tr.querySelector('.vat').addEventListener(ev,updateTotal);
+     tr.querySelector('.row-currency').addEventListener(ev,updateTotal);
+     tr.querySelector('.prod').addEventListener(ev,prodChanged);
+  });
+  updateTotal();
+}
+function prodChanged(){
+  var select=this;
+  var tr=select.closest('tr');
+  var custom=tr.querySelector('.custom');
+  var opt=select.options[select.selectedIndex];
+  if(select.value==='__new__'){
+    custom.classList.remove('d-none');
+    tr.querySelector('.price').value='';
+    tr.querySelector('.row-currency').value='TRY';
+    tr.querySelector('.vat').value='0';
+  }else{
+    custom.classList.add('d-none');
+    if(opt.dataset){
+      tr.querySelector('.price').value=opt.dataset.price||'';
+      tr.querySelector('.row-currency').value=opt.dataset.currency||'TRY';
+      tr.querySelector('.vat').value=opt.dataset.vat||'0';
+    }
+  }
+  updateTotal();
+}
+function updateTotal(){
+  var rate = <?= $usdRate ? $usdRate : 0 ?>;
+  var totalTl = 0;
+  var vatTl = 0;
+  document.querySelectorAll('#items tbody tr').forEach(function(tr){
+    var q = parseFloat(tr.querySelector('.qty').value)||0;
+    var p = parseFloat(tr.querySelector('.price').value)||0;
+    var v = parseFloat(tr.querySelector('.vat').value)||0;
+    var cur = tr.querySelector('.row-currency').value;
+    var lineSub = q*p;
+    var lineVat = lineSub*v/100;
+    var lineTl = cur==='USD' ? (lineSub+lineVat)*rate : (lineSub+lineVat);
+    tr.querySelector('.row-total').innerText=lineTl.toFixed(2);
+    totalTl += cur==='USD' ? lineSub*rate : lineSub;
+    vatTl += cur==='USD' ? lineVat*rate : lineVat;
+  });
+  document.getElementById('total').innerText=totalTl.toFixed(2);
+  document.getElementById('vat_t').innerText=vatTl.toFixed(2);
+  document.getElementById('grand').innerText=(totalTl+vatTl).toFixed(2);
+}
+document.getElementById('start').addEventListener('change',function(){
+  if(!document.getElementById('due').value){
+    var start=new Date(this.value);
+    if(start.toString()!=='Invalid Date'){
+      start.setFullYear(start.getFullYear()+1);
+      document.getElementById('due').value=start.toISOString().slice(0,10);
+    }
+  }
+});
+document.getElementById('addRow').addEventListener('click',addRow);
+addRow();
+updateTotal();
+document.getElementById('reminder').addEventListener('change',function(){
+  document.getElementById('reminder_opts').classList.toggle('d-none',!this.checked);
+});
+document.querySelector('form').addEventListener('submit',function(e){
+  var warn=false;
+  document.querySelectorAll('#items tbody tr').forEach(function(tr){
+    if(!tr.querySelector('.provider').value) warn=true;
+  });
+  if(warn && !confirm('Bazı satırlarda sağlayıcı seçilmedi, devam edilsin mi?')){
+    e.preventDefault();
+    return;
+  }
+  newProducts=[];
+  document.querySelectorAll('#items tbody tr').forEach(function(tr){
+    if(tr.querySelector('.prod').value==='__new__'){
+      var name=tr.querySelector('.custom').value.trim();
+      if(!name) return;
+      newProducts.push({
+        name:name,
+        unit:tr.querySelector('.unit').value,
+        vat_rate:tr.querySelector('.vat').value,
+        price:tr.querySelector('.price').value,
+        currency:tr.querySelector('.row-currency').value
+      });
+    }
+  });
+  document.getElementById('new_products_json').value=JSON.stringify(newProducts);
+});
+</script>
+<div class="mb-5"></div>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/service_delete.php
+++ b/service_delete.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__.'/includes/auth.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('DELETE FROM services WHERE id=?');
+$stmt->execute([$id]);
+header('Location: services.php');
+exit;

--- a/service_edit.php
+++ b/service_edit.php
@@ -1,0 +1,326 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $pdo->prepare('SELECT * FROM services WHERE id=?');
+$stmt->execute([$id]);
+$service = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$service){
+    header('Location: services.php');
+    exit;
+}
+
+$customers = $pdo->query("SELECT id, full_name FROM customers")->fetchAll(PDO::FETCH_ASSOC);
+$products = $pdo->query("SELECT id, name, price, currency, vat_rate FROM products")->fetchAll(PDO::FETCH_ASSOC);
+$providers = $pdo->query("SELECT id, name FROM providers")->fetchAll(PDO::FETCH_ASSOC);
+$usdRate = getUsdRate($pdo);
+
+$itemStmt = $pdo->prepare('SELECT * FROM service_items WHERE service_id=?');
+$itemStmt->execute([$id]);
+$items = $itemStmt->fetchAll(PDO::FETCH_ASSOC);
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $start = $_POST['start_date'];
+    $due = $_POST['due_date'] ?: date('Y-m-d', strtotime($start.' +1 year'));
+    $duration = (int)((strtotime($due) - strtotime($start))/86400);
+    $remEnabled = isset($_POST['reminder_enabled']) ? 1 : 0;
+    $remDays = $remEnabled && !empty($_POST['reminder_days']) ? implode(',', $_POST['reminder_days']) : '';
+
+    $totalTry = 0;
+    if(!empty($_POST['item_name'])){
+        foreach($_POST['item_name'] as $i => $name){
+            $qty = (float)($_POST['quantity'][$i] ?? 1);
+            $price = (float)($_POST['unit_price'][$i] ?? 0);
+            $vat = (float)($_POST['item_vat'][$i] ?? 0);
+            $cur = $_POST['item_currency'][$i] ?? 'TRY';
+            $line = $qty * $price;
+            $lineVat = $line * $vat / 100;
+            $lineTl = $cur==='USD' ? ($line + $lineVat) * $usdRate : ($line + $lineVat);
+            $totalTry += $lineTl;
+        }
+    }
+
+    $stmt = $pdo->prepare('UPDATE services SET customer_id=?, service_type=?, site_name=?, start_date=?, due_date=?, duration=?, price=?, currency=?, vat_rate=?, price_try=?, status=?, notes=?, reminder_enabled=?, reminder_days=? WHERE id=?');
+    $stmt->execute([
+        $_POST['customer_id'],
+        $_POST['service_type'],
+        $_POST['site_name'],
+        $start,
+        $due,
+        $duration,
+        $totalTry,
+        'TRY',
+        0,
+        $totalTry,
+        $_POST['status'],
+        $_POST['notes'],
+        $remEnabled,
+        $remDays,
+        $id
+    ]);
+
+    $pdo->prepare('DELETE FROM service_items WHERE service_id=?')->execute([$id]);
+    if(!empty($_POST['item_name'])){
+        $itemStmt = $pdo->prepare('INSERT INTO service_items (service_id,item_name,quantity,unit,unit_price,vat_rate,currency,provider_id,description) VALUES (?,?,?,?,?,?,?,?,?)');
+        foreach($_POST['item_name'] as $i => $n){
+            $name = $n==='__new__' ? ($_POST['item_custom'][$i] ?? '') : $n;
+            if(trim($name)==='') continue;
+            $itemStmt->execute([
+                $id,
+                $name,
+                (int)($_POST['quantity'][$i] ?? 1),
+                $_POST['unit'][$i] ?? '',
+                (float)($_POST['unit_price'][$i] ?? 0),
+                (float)($_POST['item_vat'][$i] ?? 0),
+                $_POST['item_currency'][$i] ?? 'TRY',
+                ($_POST['provider_item'][$i] ?? '') ?: null,
+                $_POST['description'][$i] ?? ''
+            ]);
+        }
+    }
+    if(!empty($_POST['new_products_json'])){
+        $new = json_decode($_POST['new_products_json'], true) ?: [];
+        $prodStmt = $pdo->prepare('INSERT INTO products(name,unit,vat_rate,price,currency) VALUES (?,?,?,?,?)');
+        foreach($new as $p){
+            $prodStmt->execute([$p['name'],$p['unit'],$p['vat_rate'],$p['price'],$p['currency']]);
+        }
+    }
+    header('Location: service.php?id='.$id);
+    exit;
+}
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hizmet Düzenle</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Müşteri</label>
+    <select name="customer_id" class="form-control" required>
+      <?php foreach($customers as $c): ?>
+      <option value="<?= $c['id'] ?>" <?= $c['id']==$service['customer_id']?'selected':'' ?>><?= htmlspecialchars($c['full_name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Hizmet Türü</label>
+    <input type="text" name="service_type" class="form-control" value="<?= htmlspecialchars($service['service_type']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Site / Alan Adı</label>
+    <input type="text" name="site_name" class="form-control" value="<?= htmlspecialchars($service['site_name']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Başlangıç Tarihi</label>
+    <input type="date" name="start_date" id="start" class="form-control" value="<?= $service['start_date'] ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Ödeme Tarihi</label>
+    <input type="date" name="due_date" id="due" class="form-control" value="<?= $service['due_date'] ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Durum</label>
+    <select name="status" class="form-control">
+      <option value="aktif" <?= $service['status']=='aktif'?'selected':'' ?>>Aktif</option>
+      <option value="pasif" <?= $service['status']=='pasif'?'selected':'' ?>>Pasif</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Not</label>
+    <textarea name="notes" class="form-control"><?= htmlspecialchars($service['notes']) ?></textarea>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="reminder" name="reminder_enabled" value="1" <?= $service['reminder_enabled']?'checked':'' ?> >
+    <label class="form-check-label" for="reminder">Mail ile hatırlatma gönderilsin mi?</label>
+  </div>
+  <div id="reminder_opts" class="mb-3 <?= $service['reminder_enabled']?'':'d-none' ?>">
+    <label class="form-label">Gönderim Günleri</label><br>
+    <?php $daysSel = explode(',', $service['reminder_days']); foreach([30,15,7,0] as $d): ?>
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="checkbox" name="reminder_days[]" value="<?= $d ?>" <?= in_array((string)$d,$daysSel)?'checked':'' ?>>
+      <label class="form-check-label"><?= $d==0?'Son gün':$d.' gün önce' ?></label>
+    </div>
+    <?php endforeach; ?>
+  </div>
+  <h3>Hizmet / Ürün Detayı</h3>
+  <table class="table" id="items">
+    <thead>
+      <tr>
+        <th>Hizmet / Ürün</th>
+        <th>Miktar</th>
+        <th>Birim</th>
+        <th>Birim Fiyat</th>
+        <th>Döviz</th>
+        <th>Sağlayıcı</th>
+        <th>KDV</th>
+        <th>Açıklama</th>
+        <th>Toplam</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach($items as $it): ?>
+      <?php $known = false; foreach($products as $p){ if($p['name']==$it['item_name']){$known=true;break;} } ?>
+      <tr>
+        <td>
+          <select name="item_name[]" class="form-control prod">
+            <option value="">Seçiniz</option>
+            <?php foreach($products as $p): ?>
+            <option value="<?= htmlspecialchars($p['name']) ?>" data-price="<?= $p['price'] ?>" data-currency="<?= $p['currency'] ?>" data-vat="<?= $p['vat_rate'] ?>" <?= $p['name']==$it['item_name']?'selected':'' ?>><?= htmlspecialchars($p['name']) ?></option>
+            <?php endforeach; ?>
+            <option value="__new__" <?= !$known?'selected':'' ?>>+ Özel Ürün</option>
+          </select>
+          <input type="text" name="item_custom[]" class="form-control mt-2 custom <?= $known?'d-none':'' ?>" placeholder="Ürün adı" value="<?= $known?'':htmlspecialchars($it['item_name']) ?>">
+        </td>
+        <td><input type="number" name="quantity[]" value="<?= $it['quantity'] ?>" class="form-control qty"></td>
+        <td><select name="unit[]" class="form-control unit">
+              <option value="adet" <?= $it['unit']=='adet'?'selected':'' ?>>Adet</option>
+              <option value="ay" <?= $it['unit']=='ay'?'selected':'' ?>>Ay</option>
+              <option value="yıl" <?= $it['unit']=='yıl'?'selected':'' ?>>Yıl</option>
+            </select></td>
+        <td><input type="text" name="unit_price[]" value="<?= $it['unit_price'] ?>" class="form-control price"></td>
+        <td><select name="item_currency[]" class="form-control row-currency">
+              <option value="TRY" <?= $it['currency']=='TRY'?'selected':'' ?>>TRY</option>
+              <option value="USD" <?= $it['currency']=='USD'?'selected':'' ?>>USD</option>
+            </select></td>
+        <td><select name="provider_item[]" class="form-control provider">
+              <option value="">Seçiniz</option>
+              <?php foreach($providers as $pr): ?>
+              <option value="<?= $pr['id'] ?>" <?= $it['provider_id']==$pr['id']?'selected':'' ?>><?= htmlspecialchars($pr['name']) ?></option>
+              <?php endforeach; ?>
+            </select></td>
+        <td><select name="item_vat[]" class="form-control vat">
+              <option value="0" <?= $it['vat_rate']==0?'selected':'' ?>>%0</option>
+              <option value="1" <?= $it['vat_rate']==1?'selected':'' ?>>%1</option>
+              <option value="10" <?= $it['vat_rate']==10?'selected':'' ?>>%10</option>
+              <option value="20" <?= $it['vat_rate']==20?'selected':'' ?>>%20</option>
+            </select></td>
+        <td><input type="text" name="description[]" value="<?= htmlspecialchars($it['description']) ?>" class="form-control desc"></td>
+        <td class="row-total">0</td>
+        <td><button type="button" class="btn btn-sm btn-danger remove-row">X</button></td>
+      </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+  <button type="button" class="btn btn-secondary mb-3" id="addRow">Satır Ekle</button>
+  <div class="mb-3 text-end">
+    <strong>Toplam Tutar (TL): <span id="total">0</span></strong><br>
+    <strong>KDV Tutarı (TL): <span id="vat_t">0</span></strong><br>
+    <strong>Güncel Kur: <span id="rate"><?= number_format($usdRate,2,',','.') ?></span></strong><br>
+    <strong>Genel Toplam (TL): <span id="grand">0</span></strong>
+  </div>
+  <input type="hidden" name="new_products_json" id="new_products_json">
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="service.php?id=<?= $service['id'] ?>" class="btn btn-secondary">İptal</a>
+</form>
+<script>
+var productOptions = '<?php foreach($products as $p){echo "<option value=\"".$p['name']."\" data-price=\"{$p['price']}\" data-currency=\"{$p['currency']}\" data-vat=\"{$p['vat_rate']}\">".htmlspecialchars($p['name'])."</option>";} ?>' + '<option value="__new__">+ Özel Ürün</option>';
+var providerOptions = '<?php foreach($providers as $p){echo "<option value=\"{$p['id']}\">".htmlspecialchars($p['name'])."</option>";} ?>';
+var newProducts = [];
+function initRow(tr){
+  tr.querySelector('.remove-row').addEventListener('click',function(){tr.remove();updateTotal();});
+  ['input','change'].forEach(function(ev){
+     tr.querySelector('.qty').addEventListener(ev,updateTotal);
+     tr.querySelector('.price').addEventListener(ev,updateTotal);
+     tr.querySelector('.vat').addEventListener(ev,updateTotal);
+     tr.querySelector('.row-currency').addEventListener(ev,updateTotal);
+     tr.querySelector('.prod').addEventListener(ev,prodChanged);
+  });
+}
+function addRow(){
+  var tbody=document.querySelector('#items tbody');
+  var tr=document.createElement('tr');
+  tr.innerHTML='<td><select name="item_name[]" class="form-control prod"><option value="">Seçiniz</option>'+productOptions+'</select><input type="text" name="item_custom[]" class="form-control mt-2 d-none custom" placeholder="Ürün adı"></td>'+
+    '<td><input type="number" name="quantity[]" value="1" class="form-control qty"></td>'+
+    '<td><select name="unit[]" class="form-control unit">'+
+      '<option value="adet">Adet</option><option value="ay">Ay</option><option value="yıl">Yıl</option>'+
+    '</select></td>'+
+    '<td><input type="text" name="unit_price[]" class="form-control price"></td>'+
+    '<td><select name="item_currency[]" class="form-control row-currency"><option value="TRY">TRY</option><option value="USD">USD</option></select></td>'+
+    '<td><select name="provider_item[]" class="form-control provider"><option value="">Seçiniz</option>'+providerOptions+'</select></td>'+
+    '<td><select name="item_vat[]" class="form-control vat">'+
+       '<option value="0">%0</option><option value="1">%1</option><option value="10">%10</option><option value="20">%20</option>'+
+    '</select></td>'+
+    '<td><input type="text" name="description[]" class="form-control desc"></td>'+
+    '<td class="row-total">0</td>'+
+    '<td><button type="button" class="btn btn-sm btn-danger remove-row">X</button></td>';
+  tbody.appendChild(tr);
+  initRow(tr);
+  updateTotal();
+}
+function prodChanged(){
+  var select=this;
+  var tr=select.closest('tr');
+  var custom=tr.querySelector('.custom');
+  var opt=select.options[select.selectedIndex];
+  if(select.value==='__new__'){
+    custom.classList.remove('d-none');
+    tr.querySelector('.price').value='';
+    tr.querySelector('.row-currency').value='TRY';
+    tr.querySelector('.vat').value='0';
+  }else{
+    custom.classList.add('d-none');
+    if(opt.dataset){
+      tr.querySelector('.price').value=opt.dataset.price||'';
+      tr.querySelector('.row-currency').value=opt.dataset.currency||'TRY';
+      tr.querySelector('.vat').value=opt.dataset.vat||'0';
+    }
+  }
+  updateTotal();
+}
+function updateTotal(){
+  var rate = <?= $usdRate ? $usdRate : 0 ?>;
+  var totalTl = 0;
+  var vatTl = 0;
+  document.querySelectorAll('#items tbody tr').forEach(function(tr){
+    var q = parseFloat(tr.querySelector('.qty').value)||0;
+    var p = parseFloat(tr.querySelector('.price').value)||0;
+    var v = parseFloat(tr.querySelector('.vat').value)||0;
+    var cur = tr.querySelector('.row-currency').value;
+    var lineSub = q*p;
+    var lineVat = lineSub*v/100;
+    var lineTl = cur==='USD' ? (lineSub+lineVat)*rate : (lineSub+lineVat);
+    tr.querySelector('.row-total').innerText=lineTl.toFixed(2);
+    totalTl += cur==='USD' ? lineSub*rate : lineSub;
+    vatTl += cur==='USD' ? lineVat*rate : lineVat;
+  });
+  document.getElementById('total').innerText=totalTl.toFixed(2);
+  document.getElementById('vat_t').innerText=vatTl.toFixed(2);
+  document.getElementById('grand').innerText=(totalTl+vatTl).toFixed(2);
+}
+
+document.querySelectorAll('#items tbody tr').forEach(initRow);
+document.getElementById('addRow').addEventListener('click',addRow);
+updateTotal();
+document.getElementById('reminder').addEventListener('change',function(){
+  document.getElementById('reminder_opts').classList.toggle('d-none',!this.checked);
+});
+
+document.querySelector('form').addEventListener('submit',function(e){
+  var warn=false;
+  document.querySelectorAll('#items tbody tr').forEach(function(tr){
+    if(!tr.querySelector('.provider').value) warn=true;
+  });
+  if(warn && !confirm('Bazı satırlarda sağlayıcı seçilmedi, devam edilsin mi?')){
+    e.preventDefault();
+    return;
+  }
+  newProducts=[];
+  document.querySelectorAll('#items tbody tr').forEach(function(tr){
+    if(tr.querySelector('.prod').value==='__new__'){
+      var name=tr.querySelector('.custom').value.trim();
+      if(!name) return;
+      newProducts.push({
+        name:name,
+        unit:tr.querySelector('.unit').value,
+        vat_rate:tr.querySelector('.vat').value,
+        price:tr.querySelector('.price').value,
+        currency:tr.querySelector('.row-currency').value
+      });
+    }
+  });
+  document.getElementById('new_products_json').value=JSON.stringify(newProducts);
+});
+</script>
+<div class="mb-5"></div>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/service_payment.php
+++ b/service_payment.php
@@ -1,0 +1,130 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+$service_id = isset($_GET['service_id']) ? (int)$_GET['service_id'] : 0;
+$stmt = $pdo->prepare('SELECT s.*, c.full_name FROM services s JOIN customers c ON s.customer_id=c.id WHERE s.id=?');
+$stmt->execute([$service_id]);
+$service = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$service){
+    header('Location: services.php');
+    exit;
+}
+$customer_id = $service['customer_id'];
+
+$usdRate = getUsdRate($pdo);
+
+// mevcut borcu hesapla
+$paidStmt = $pdo->prepare('SELECT SUM(amount_try) FROM payments WHERE service_id=?');
+$paidStmt->execute([$service_id]);
+$paid_try = (float)$paidStmt->fetchColumn();
+$service_total_try = $service['price_try'] * (1 + $service['vat_rate']/100);
+$remain_try = $service_total_try - $paid_try;
+if ($remain_try < 0) $remain_try = 0;
+$remain_cur = $service['currency'] === 'USD' ? ($remain_try / ($usdRate ?: 1)) : $remain_try;
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $amount = (float)$_POST['amount'];
+    $currency = $_POST['currency'];
+    $amount_try = $currency==='USD' ? $amount * $usdRate : $amount;
+    $stmt = $pdo->prepare('INSERT INTO payments (customer_id, service_id, amount_try, amount_orig, currency) VALUES (?,?,?,?,?)');
+    $stmt->execute([$customer_id, $service_id, $amount_try, $amount, $currency]);
+
+    if(isset($_POST['renew'])){
+        $years = (int)$_POST['years'];
+        $renew_price = (float)$_POST['renew_price'];
+        $renew_currency = $_POST['renew_currency'];
+        $renew_vat_rate = (float)$_POST['renew_vat_rate'];
+        $renew_apply_vat = isset($_POST['renew_apply_vat']);
+        $price = $renew_price * $years;
+        if($renew_apply_vat){
+            $price *= (1 + $renew_vat_rate/100);
+        }
+        $price_try = $renew_currency==='USD' ? $price * $usdRate : $price;
+        $start = $service['due_date'];
+        $due = date('Y-m-d', strtotime($start.' +'.$years.' year'));
+        $duration = (int)((strtotime($due)-strtotime($start))/86400);
+        $stmt = $pdo->prepare("INSERT INTO services (customer_id, product_id, provider_id, site_name, service_type, start_date, due_date, duration, unit, price, currency, vat_rate, price_try, status, notes, created_at) VALUES (?,?,?,?,?,?,?,?, 'gün', ?, ?, ?, ?, ?, ?, NOW())");
+        $stmt->execute([$customer_id,$service['product_id'],$service['provider_id'],$service['site_name'],$service['service_type'],$start,$due,$duration,$renew_price*$years,$renew_currency,$renew_vat_rate,$price_try,$service['status'],$service['notes']]);
+    }
+
+    header('Location: customer.php?id='.$customer_id);
+    exit;
+}
+
+$total_default = $service['price'];
+$default_years = 1;
+$default_apply_vat = true;
+$calc_total = function($yrs,$vat) use($service){
+    $price = $service['price'] * $yrs;
+    if($vat){
+        $price *= (1 + $service['vat_rate']/100);
+    }
+    return $price;
+};
+
+include __DIR__.'/includes/header.php';
+?>
+<h1>Hizmet Tahsilatı - <?= htmlspecialchars($service['full_name']) ?></h1>
+<p>Hizmet: <?= htmlspecialchars($service['service_type']) ?> - <?= htmlspecialchars($service['site_name']) ?></p>
+<p><strong>Toplam Borç:</strong> <?= number_format($remain_cur,2,',','.') ?> <?= $service['currency'] ?> (<?= number_format($remain_try,2,',','.') ?> TL)</p>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Tutar</label>
+    <input type="text" name="amount" class="form-control" value="<?= number_format($remain_cur,2,'.','') ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Para Birimi</label>
+    <select name="currency" class="form-control">
+      <option value="TRY" <?= $service['currency']=='TRY'?'selected':'' ?>>TL</option>
+      <option value="USD" <?= $service['currency']=='USD'?'selected':'' ?>>USD</option>
+    </select>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="renew" name="renew">
+    <label class="form-check-label" for="renew">Tahsilattan sonra hizmeti uzat</label>
+  </div>
+  <div id="renewFields" style="display:none;">
+    <div class="mb-3">
+      <label class="form-label">Kaç Yıl Uzatılsın</label>
+      <select name="years" class="form-control">
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Fiyat</label>
+      <input type="text" name="renew_price" id="renew_price" value="<?= $service['price'] ?>" class="form-control">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Para Birimi</label>
+      <select name="renew_currency" id="renew_currency" class="form-control">
+        <option value="TRY" <?= $service['currency']=='TRY'?'selected':'' ?>>TL</option>
+        <option value="USD" <?= $service['currency']=='USD'?'selected':'' ?>>USD</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">KDV Oranı</label>
+      <select name="renew_vat_rate" id="renew_vat_rate" class="form-control">
+        <option value="0" <?= $service['vat_rate']==0?'selected':'' ?>>Yok</option>
+        <option value="10" <?= $service['vat_rate']==10?'selected':'' ?>>%10</option>
+        <option value="20" <?= $service['vat_rate']==20?'selected':'' ?>>%20</option>
+      </select>
+    </div>
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" name="renew_apply_vat" id="renew_vat" <?= $service['vat_rate']>0?'checked':'' ?>>
+      <label class="form-check-label" for="renew_vat">KDV Eklensin</label>
+    </div>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+  <a href="customer.php?id=<?= $customer_id ?>" class="btn btn-secondary">İptal</a>
+</form>
+<script>
+ document.getElementById('renew').addEventListener('change',function(){
+   document.getElementById('renewFields').style.display=this.checked?'block':'none';
+ });
+</script>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/services.php
+++ b/services.php
@@ -1,0 +1,57 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+include __DIR__.'/includes/header.php';
+
+$stmt = $pdo->query("SELECT s.*, c.full_name FROM services s JOIN customers c ON s.customer_id=c.id ORDER BY s.id DESC");
+$services = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$usdRate = getUsdRate($pdo);
+?>
+<h1>Hizmetler</h1>
+<a href="service_add.php" class="btn btn-primary mb-3">Hizmet Ekle</a>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+       <th>ID</th>
+       <th>Müşteri</th>
+       <th>Hizmet Türü</th>
+       <th>Site</th>
+       <th>Başlangıç</th>
+       <th>Ödeme Tarihi</th>
+       <th>Fiyat</th>
+       <th>Fiyat TL</th>
+       <th>KDV</th>
+       <th>Genel Toplam</th>
+       <th>Durum</th>
+       <th>Not</th>
+       <th>Oluşturma</th>
+       <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($services as $s): ?>
+    <tr>
+      <td><?= $s['id'] ?></td>
+      <td><?= htmlspecialchars($s['full_name']) ?></td>
+      <td><?= htmlspecialchars($s['service_type']) ?></td>
+      <td><?= htmlspecialchars($s['site_name']) ?></td>
+      <td><?= date('d.m.Y', strtotime($s['start_date'])) ?></td>
+      <td><?= date('d.m.Y', strtotime($s['due_date'])) ?></td>
+      <td><?= number_format($s['price'],2,',','.') . ' ' . $s['currency'] ?></td>
+      <td><?= number_format($s['price_try'],2,',','.') ?> ₺</td>
+      <td><?= $s['vat_rate'] ?>%</td>
+      <td><?= number_format($s['price_try'] * (1 + $s['vat_rate']/100), 2, ',', '.') ?> ₺</td>
+      <td><?= htmlspecialchars($s['status']) ?></td>
+      <td><?= htmlspecialchars($s['notes']) ?></td>
+      <td><?= date('d.m.Y', strtotime($s['created_at'])) ?></td>
+      <td>
+        <a href="service.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-info">Detay</a>
+        <a href="service_payment.php?service_id=<?= $s['id'] ?>" class="btn btn-sm btn-primary">Tahsilat</a>
+        <a href="service_edit.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="service_delete.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>
+<?php include __DIR__.'/includes/footer.php'; ?>

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,99 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$settings = [];
+$keys = ['logo','logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height'];
+foreach ($keys as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt->execute([$k]);
+    $settings[$k] = $stmt->fetchColumn() ?: '';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $save_message = '';
+    if (!empty($_FILES['logo']['tmp_name'])) {
+        $dir = 'uploads';
+        if (!is_dir($dir)) mkdir($dir, 0777, true);
+        $path = $dir . '/' . basename($_FILES['logo']['name']);
+        move_uploaded_file($_FILES['logo']['tmp_name'], $path);
+        $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES ('logo', ?)");
+        $stmt->execute([$path]);
+        $settings['logo'] = $path;
+    }
+    if(!empty($_FILES['footer_logo']['tmp_name'])){
+        $dir = 'uploads';
+        if(!is_dir($dir)) mkdir($dir,0777,true);
+        $path = $dir.'/'.basename($_FILES['footer_logo']['name']);
+        move_uploaded_file($_FILES['footer_logo']['tmp_name'],$path);
+        $stmt = $pdo->prepare("REPLACE INTO settings (`key`,value) VALUES ('footer_logo',?)");
+        $stmt->execute([$path]);
+        $settings['footer_logo']=$path;
+    }
+    foreach (['logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height'] as $k) {
+        if (isset($_POST[$k])) {
+            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES (?, ?)");
+            $stmt->execute([$k, $_POST[$k]]);
+            $settings[$k] = $_POST[$k];
+        }
+    }
+    $save_message = 'Ayarlar kaydedildi';
+}
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Genel Ayarlar</h1>
+<form method="post" enctype="multipart/form-data">
+  <div class="mb-3">
+    <label class="form-label">Logo Yükle</label>
+    <input type="file" name="logo" class="form-control">
+  </div>
+  <?php if ($settings['logo']): ?>
+  <div class="mb-3">
+    <img src="/<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" style="max-width:200px;">
+  </div>
+  <?php endif; ?>
+  <div class="row">
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Login Logo Genişlik</label>
+      <input type="number" name="logo_login_width" class="form-control" value="<?= htmlspecialchars($settings['logo_login_width']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Login Logo Yükseklik</label>
+      <input type="number" name="logo_login_height" class="form-control" value="<?= htmlspecialchars($settings['logo_login_height']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Header Logo Genişlik</label>
+      <input type="number" name="logo_header_width" class="form-control" value="<?= htmlspecialchars($settings['logo_header_width']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Header Logo Yükseklik</label>
+      <input type="number" name="logo_header_height" class="form-control" value="<?= htmlspecialchars($settings['logo_header_height']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Footer Yazısı</label>
+      <input type="text" name="footer_text" class="form-control" value="<?= htmlspecialchars($settings['footer_text']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Footer Logo</label>
+      <input type="file" name="footer_logo" class="form-control">
+      <?php if($settings['footer_logo']): ?>
+      <img src="/<?= htmlspecialchars($settings['footer_logo']) ?>" alt="footer" style="max-width:200px;" class="mt-2">
+      <?php endif; ?>
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Footer Logo Genişlik</label>
+      <input type="number" name="footer_logo_width" class="form-control" value="<?= htmlspecialchars($settings['footer_logo_width']) ?>">
+    </div>
+    <div class="col-md-6 mb-3">
+      <label class="form-label">Footer Logo Yükseklik</label>
+      <input type="number" name="footer_logo_height" class="form-control" value="<?= htmlspecialchars($settings['footer_logo_height']) ?>">
+    </div>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php if(!empty($save_message)): ?>
+<div class="alert alert-success mt-3">
+  <?= $save_message ?>
+</div>
+<?php endif; ?>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,162 @@
+CREATE TABLE customers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  full_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255),
+  phone VARCHAR(50),
+  company VARCHAR(255),
+  address TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE products (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255),
+  unit VARCHAR(20),
+  vat_rate DECIMAL(5,2),
+  price DECIMAL(10,2),
+  currency VARCHAR(10),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE providers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255),
+  website VARCHAR(255),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+ ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE services (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  customer_id INT NOT NULL,
+  product_id INT,
+  provider_id INT,
+  site_name VARCHAR(255),
+  service_type VARCHAR(50),
+  start_date DATE,
+  due_date DATE,
+  duration INT,
+  unit VARCHAR(10),
+  price DECIMAL(10,2),
+  currency VARCHAR(10),
+  vat_rate DECIMAL(5,2),
+  price_try DECIMAL(10,2),
+  status VARCHAR(20),
+  notes TEXT,
+  reminder_enabled TINYINT(1) DEFAULT 0,
+  reminder_days VARCHAR(50),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE,
+  FOREIGN KEY (product_id) REFERENCES products(id),
+  FOREIGN KEY (provider_id) REFERENCES providers(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE service_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  service_id INT NOT NULL,
+  item_name VARCHAR(255),
+  quantity INT DEFAULT 1,
+  unit VARCHAR(20),
+  unit_price DECIMAL(10,2),
+  vat_rate DECIMAL(5,2),
+  currency VARCHAR(10),
+  provider_id INT,
+  description TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE,
+  FOREIGN KEY (provider_id) REFERENCES providers(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE exchange_rates (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  rate_date DATE,
+  usd_try DECIMAL(10,4),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE payments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  customer_id INT NOT NULL,
+  service_id INT,
+  amount_try DECIMAL(10,2),
+  amount_orig DECIMAL(10,2),
+  currency VARCHAR(10),
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE,
+  FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(100) UNIQUE,
+  password VARCHAR(255),
+  role ENUM('admin','user') DEFAULT 'admin',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE settings (
+  `key` VARCHAR(50) PRIMARY KEY,
+  value TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE provider_purchases (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  provider_id INT NOT NULL,
+  item_name VARCHAR(255),
+  quantity INT DEFAULT 1,
+  unit VARCHAR(20),
+  unit_price DECIMAL(10,2),
+  vat_rate DECIMAL(5,2),
+  currency VARCHAR(10),
+  purchase_date DATE,
+  payment_date DATE,
+  price_try DECIMAL(10,2),
+  notes TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE email_logs (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  service_id INT,
+  client_id INT,
+  email_to VARCHAR(255),
+  subject VARCHAR(255),
+  content TEXT,
+  sent_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE,
+  FOREIGN KEY (client_id) REFERENCES customers(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE provider_payments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  provider_id INT NOT NULL,
+  amount_try DECIMAL(10,2),
+  amount_orig DECIMAL(10,2),
+  currency VARCHAR(10),
+  pay_date DATE,
+  notes TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO users (email, password, role) VALUES
+('info@precadmedya.com.tr', '$2y$12$g0QsFECHVjIwr2WhxPLLV.i/wskHA2S0VuZY0bowUph3KdXmaZ3MS', 'admin');
+
+INSERT INTO settings (`key`, value) VALUES
+('logo', ''),
+('logo_login_width','140'),
+('logo_login_height','40'),
+('logo_header_width','120'),
+('logo_header_height','40'),
+('mail_logo',''),
+('smtp_host','smtp.yandex.com.tr'),
+('smtp_port','465'),
+('smtp_encryption','ssl'),
+('smtp_user','info@precadmedya.com.tr'),
+('smtp_pass','Precadmedya34523'),
+('smtp_from_name','Precad Medya'),
+('smtp_from_email','info@precadmedya.com.tr'),
+('footer_text','Precad Medya 2025 Tüm Hakları Saklıdır.'),
+('footer_logo',''),
+('footer_logo_width','120'),
+('footer_logo_height','40');

--- a/update_rates.php
+++ b/update_rates.php
@@ -1,0 +1,50 @@
+<?php
+require __DIR__.'/includes/auth.php';
+require __DIR__.'/includes/functions.php';
+
+function fetchTodayRate(PDO $pdo): float{
+    $xml = @simplexml_load_file('https://www.tcmb.gov.tr/kurlar/today.xml');
+    $rate = 0;
+    if($xml){
+        foreach($xml->Currency as $cur){
+            if((string)$cur['CurrencyCode']=='USD'){
+                $rate = (float)str_replace(',', '.', (string)$cur->BanknoteSelling);
+                break;
+            }
+        }
+    }
+    if($rate){
+        $stmt=$pdo->prepare('SELECT id FROM exchange_rates WHERE rate_date=CURDATE()');
+        $stmt->execute();
+        if($stmt->fetchColumn()){
+            $u=$pdo->prepare('UPDATE exchange_rates SET usd_try=? WHERE rate_date=CURDATE()');
+            $u->execute([$rate]);
+        }else{
+            $i=$pdo->prepare('INSERT INTO exchange_rates(rate_date,usd_try) VALUES(CURDATE(),?)');
+            $i->execute([$rate]);
+        }
+    }
+    return $rate;
+}
+
+$rate = fetchTodayRate($pdo);
+if($rate){
+    $svc = $pdo->query('SELECT id FROM services');
+    while($s = $svc->fetch(PDO::FETCH_ASSOC)){
+        $its = $pdo->prepare('SELECT * FROM service_items WHERE service_id=?');
+        $its->execute([$s['id']]);
+        $t=0;$v=0;
+        foreach($its->fetchAll(PDO::FETCH_ASSOC) as $it){
+            $sub=$it['quantity']*$it['unit_price'];
+            $vat=$sub*$it['vat_rate']/100;
+            if($it['currency']==='USD'){ $sub*=$rate; $vat*=$rate; }
+            $t+=$sub; $v+=$vat;
+        }
+        $total=$t+$v;
+        $pdo->prepare('UPDATE services SET price=?,price_try=? WHERE id=?')->execute([$total,$total,$s['id']]);
+    }
+    $_SESSION['message']='Kur güncellendi: '.number_format($rate,4,',','.');
+}else{
+    $_SESSION['message']='Kur alınamadı';
+}
+header('Location: '.($_SERVER['HTTP_REFERER'] ?? 'dashboard.php'));

--- a/users.php
+++ b/users.php
@@ -1,0 +1,90 @@
+<?php
+require __DIR__ . '/includes/auth.php';
+
+$action = $_GET['action'] ?? '';
+$id = $_GET['id'] ?? null;
+
+if ($action === 'delete' && $id) {
+    $stmt = $pdo->prepare('DELETE FROM users WHERE id=?');
+    $stmt->execute([$id]);
+    header('Location: users.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'];
+    $role = $_POST['role'];
+    if ($action === 'edit' && $id) {
+        if (!empty($_POST['password'])) {
+            $pass = password_hash($_POST['password'], PASSWORD_BCRYPT);
+            $stmt = $pdo->prepare('UPDATE users SET email=?, password=?, role=? WHERE id=?');
+            $stmt->execute([$email, $pass, $role, $id]);
+        } else {
+            $stmt = $pdo->prepare('UPDATE users SET email=?, role=? WHERE id=?');
+            $stmt->execute([$email, $role, $id]);
+        }
+    } else {
+        $pass = password_hash($_POST['password'], PASSWORD_BCRYPT);
+        $stmt = $pdo->prepare('INSERT INTO users (email, password, role) VALUES (?, ?, ?)');
+        $stmt->execute([$email, $pass, $role]);
+    }
+    header('Location: users.php');
+    exit;
+}
+
+$editUser = null;
+if ($action === 'edit' && $id) {
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE id=?');
+    $stmt->execute([$id]);
+    $editUser = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+$users = $pdo->query('SELECT * FROM users ORDER BY id DESC')->fetchAll(PDO::FETCH_ASSOC);
+
+include __DIR__ . '/includes/header.php';
+?>
+<h1>Kullanıcılar</h1>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>E-Posta</th>
+      <th>Rol</th>
+      <th>İşlem</th>
+    </tr>
+  </thead>
+  <tbody>
+    <?php foreach ($users as $u): ?>
+    <tr>
+      <td><?= $u['id'] ?></td>
+      <td><?= htmlspecialchars($u['email']) ?></td>
+      <td><?= $u['role'] ?></td>
+      <td>
+        <a href="users.php?action=edit&id=<?= $u['id'] ?>" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="users.php?action=delete&id=<?= $u['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?')">Sil</a>
+      </td>
+    </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>
+<hr>
+<h2><?= $editUser ? 'Kullanıcı Düzenle' : 'Yeni Kullanıcı' ?></h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">E-Posta</label>
+    <input type="email" name="email" class="form-control" value="<?= $editUser['email'] ?? '' ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Şifre<?= $editUser ? ' (değiştirmek için doldur)' : '' ?></label>
+    <input type="password" name="password" class="form-control" <?= $editUser ? '' : 'required' ?>>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Rol</label>
+    <select name="role" class="form-control">
+      <option value="admin" <?= isset($editUser) && $editUser['role']==='admin' ? 'selected' : '' ?>>Admin</option>
+      <option value="user" <?= isset($editUser) && $editUser['role']==='user' ? 'selected' : '' ?>>User</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Kaydet</button>
+</form>
+<?php include __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- default `sendMail` sender name and email if settings are empty
- clarify README about fallback values and subject handling

## Testing
- `php -v | head -n 1`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_687ecc6713948333a3c2bf44a8c3072c