### PR TITLE
Add services CSV import/export and due date sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Bu proje, domain ve hosting hizmetlerini takip etmek için basit bir PHP panelid
 - `/customer_delete.php` – Müşteri silme
 - `/customers.php?export=1` – Müşterileri CSV olarak dışa aktarır; aynı sayfada
   yer alan "CSV İçe Aktar" formu ile düzenlenmiş liste yeniden yüklenebilir
- - `/services.php` – Hizmet listesi
+ - `/services.php` – Hizmet listesi (CSV dışa/içe aktarım destekler ve liste varsayılan olarak en yakın ödeme tarihine göre sıralanır)
  - `/service_payment.php` – Hizmet tahsilatı ve yenileme
    (mevcut borcu görüntüler ve ödeme sonrası uzatma seçeneği sunar)
  - `/service_add.php` – Hizmet ekleme formu. Ürün satırında seçim yapıldığında fiyat, döviz ve KDV otomatik dolar.
@@ -94,6 +94,8 @@ Müşteri tablosu varsayılan olarak şirket adına göre alfabetik sıralanır.
 Aynı sayfadan mevcut müşteri listesini CSV olarak dışa aktarabilir veya düzenlenmiş bir CSV dosyası yükleyerek kayıtları toplu güncelleyebilirsiniz.
 
 Ürünler sayfası da benzer şekilde çalışır. Liste varsayılan olarak ürün adına göre alfabetik sıralanır. İstenirse kayıtlar `products.csv` olarak dışa aktarılabilir ve düzenlenen dosya tekrar yüklenerek ürünler toplu güncellenebilir.
+
+Hizmetler sayfasında da liste `services.csv` olarak dışa aktarılabilir ve düzenlenen CSV tekrar yüklenerek yeni hizmetler eklenebilir ya da mevcut kayıtlar güncellenebilir. Hizmet listesi varsayılan olarak en yakın ödeme tarihine göre sıralanır.
 
 Tüm arayüz Türkçe olup Bootstrap 5 ile mobil uyumlu tasarlanmıştır. Sayfalara erişmek için oturum açmak gereklidir.
 Logo yükleme sayfasında giriş ve üst menüde kullanılacak logonun boyutları ayarlanabilir. Aynı ekranda alt bilgi metni ve footer logosu da düzenlenebilir.

--- a/services.php
+++ b/services.php
@@ -1,14 +1,79 @@
 <?php
 require __DIR__.'/includes/auth.php';
 require __DIR__.'/includes/functions.php';
+
+// CSV export
+if (isset($_GET['export'])) {
+    header('Content-Type: text/csv; charset=utf-8');
+    header('Content-Disposition: attachment; filename=services.csv');
+    $out = fopen('php://output', 'w');
+    fputcsv($out, ['id','customer_id','service_type','site_name','start_date','due_date','price','currency','vat_rate','price_try','status','notes']);
+    $stmt = $pdo->query('SELECT id, customer_id, service_type, site_name, start_date, due_date, price, currency, vat_rate, price_try, status, notes FROM services ORDER BY id');
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        fputcsv($out, $row);
+    }
+    fclose($out);
+    exit;
+}
+
+// CSV import
+if (isset($_POST['import']) && isset($_FILES['import_file']) && is_uploaded_file($_FILES['import_file']['tmp_name'])) {
+    $file = fopen($_FILES['import_file']['tmp_name'], 'r');
+    $header = fgetcsv($file);
+    $count = 0;
+    if ($header) {
+        $usdRate = getUsdRate($pdo);
+        while (($data = fgetcsv($file)) !== false) {
+            $row = array_combine($header, $data);
+            if (!$row) continue;
+            $customerId = $row['customer_id'] ?? null;
+            if (!$customerId) continue;
+            $price = (float)($row['price'] ?? 0);
+            $currency = $row['currency'] ?? 'TRY';
+            $vat = (float)($row['vat_rate'] ?? 0);
+            $priceTry = $row['price_try'] ?? null;
+            if ($priceTry === null || $priceTry === '') {
+                $priceTry = $currency === 'USD' ? $price * $usdRate : $price;
+                $priceTry += $priceTry * $vat / 100;
+            }
+            $duration = 0;
+            if (!empty($row['start_date']) && !empty($row['due_date'])) {
+                $duration = (int)((strtotime($row['due_date']) - strtotime($row['start_date'])) / 86400);
+            }
+            $id = $row['id'] ?? null;
+            if ($id) {
+                $stmt = $pdo->prepare('SELECT id FROM services WHERE id=?');
+                $stmt->execute([$id]);
+                if ($stmt->fetchColumn()) {
+                    $u = $pdo->prepare('UPDATE services SET customer_id=?, service_type=?, site_name=?, start_date=?, due_date=?, duration=?, unit=?, price=?, currency=?, vat_rate=?, price_try=?, status=?, notes=? WHERE id=?');
+                    $u->execute([$customerId, $row['service_type'], $row['site_name'], $row['start_date'], $row['due_date'], $duration, 'gün', $price, $currency, $vat, $priceTry, $row['status'], $row['notes'], $id]);
+                    $count++;
+                    continue;
+                }
+            }
+            $i = $pdo->prepare("INSERT INTO services (customer_id, product_id, provider_id, site_name, service_type, start_date, due_date, duration, unit, price, currency, vat_rate, price_try, status, notes, reminder_enabled, reminder_days, created_at) VALUES (?, NULL, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, '', NOW())");
+            $i->execute([$customerId, $row['site_name'], $row['service_type'], $row['start_date'], $row['due_date'], $duration, 'gün', $price, $currency, $vat, $priceTry, $row['status'], $row['notes']]);
+            $count++;
+        }
+    }
+    fclose($file);
+    $_SESSION['message'] = $count.' kayıt içeri aktarıldı';
+    header('Location: services.php');
+    exit;
+}
+
 include __DIR__.'/includes/header.php';
 
-$stmt = $pdo->query("SELECT s.*, c.full_name FROM services s JOIN customers c ON s.customer_id=c.id ORDER BY s.id DESC");
+$stmt = $pdo->query("SELECT s.*, c.full_name FROM services s JOIN customers c ON s.customer_id=c.id ORDER BY s.due_date ASC");
 $services = $stmt->fetchAll(PDO::FETCH_ASSOC);
-$usdRate = getUsdRate($pdo);
 ?>
 <h1>Hizmetler</h1>
 <a href="service_add.php" class="btn btn-primary mb-3">Hizmet Ekle</a>
+<a href="services.php?export=1" class="btn btn-secondary mb-3 ms-2">CSV Dışa Aktar</a>
+<form method="post" enctype="multipart/form-data" class="d-inline-block mb-3 ms-2">
+  <input type="file" name="import_file" accept=".csv" required class="form-control d-inline-block" style="width:auto;">
+  <button type="submit" name="import" class="btn btn-secondary">CSV İçe Aktar</button>
+</form>
 <table class="table table-bordered">
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
- enable CSV export/import on services listing
- default service ordering by nearest payment date

## Testing
- `php -l services.php`


------
https://chatgpt.com/codex/tasks/task_e_689f18761718833384f0ff3558824e7c