### PR TITLE
Add admin/firma roles with per-user data separation

### DIFF
--- a/customer.php
+++ b/customer.php
@@ -3,8 +3,14 @@ require __DIR__.'/includes/auth.php';
 require __DIR__.'/includes/functions.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
-$stmt->execute([$id]);
+$params = [$id];
+$sql = 'SELECT * FROM customers WHERE id=?';
+if($_SESSION['role'] !== 'admin') {
+    $sql .= ' AND user_id=?';
+    $params[] = $_SESSION['user_id'];
+}
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
 $customer = $stmt->fetch(PDO::FETCH_ASSOC);
 if(!$customer){
     header('Location: customers.php');

--- a/customer_add.php
+++ b/customer_add.php
@@ -2,13 +2,14 @@
 require __DIR__.'/includes/auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $stmt = $pdo->prepare("INSERT INTO customers (full_name, email, phone, company, address, created_at) VALUES (?, ?, ?, ?, ?, NOW())");
+    $stmt = $pdo->prepare("INSERT INTO customers (full_name, email, phone, company, address, user_id, created_at) VALUES (?, ?, ?, ?, ?, ?, NOW())");
     $stmt->execute([
         $_POST['full_name'],
         $_POST['email'],
         $_POST['phone'],
         $_POST['company'],
-        $_POST['address']
+        $_POST['address'],
+        $_SESSION['user_id']
     ]);
     header('Location: customers.php');
     exit;

--- a/customer_delete.php
+++ b/customer_delete.php
@@ -1,7 +1,13 @@
 <?php
 require __DIR__.'/includes/auth.php';
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$stmt = $pdo->prepare('DELETE FROM customers WHERE id=?');
-$stmt->execute([$id]);
+$sql = 'DELETE FROM customers WHERE id=?';
+$params = [$id];
+if($_SESSION['role'] !== 'admin') {
+    $sql .= ' AND user_id=?';
+    $params[] = $_SESSION['user_id'];
+}
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
 header('Location: customers.php');
 exit;

--- a/customer_edit.php
+++ b/customer_edit.php
@@ -2,8 +2,8 @@
 require __DIR__.'/includes/auth.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=?');
-$stmt->execute([$id]);
+$stmt = $pdo->prepare('SELECT * FROM customers WHERE id=? AND user_id=?');
+$stmt->execute([$id, $_SESSION['user_id']]);
 $customer = $stmt->fetch(PDO::FETCH_ASSOC);
 if(!$customer){
     header('Location: customers.php');
@@ -11,14 +11,15 @@ if(!$customer){
 }
 
 if($_SERVER['REQUEST_METHOD']==='POST'){
-    $stmt = $pdo->prepare('UPDATE customers SET full_name=?, email=?, phone=?, company=?, address=? WHERE id=?');
+    $stmt = $pdo->prepare('UPDATE customers SET full_name=?, email=?, phone=?, company=?, address=? WHERE id=? AND user_id=?');
     $stmt->execute([
         $_POST['full_name'],
         $_POST['email'],
         $_POST['phone'],
         $_POST['company'],
         $_POST['address'],
-        $id
+        $id,
+        $_SESSION['user_id']
     ]);
     header('Location: customers.php');
     exit;

--- a/customers.php
+++ b/customers.php
@@ -8,7 +8,12 @@ if (isset($_GET['export'])) {
     header('Content-Disposition: attachment; filename=customers.csv');
     $out = fopen('php://output', 'w');
     fputcsv($out, ['id','full_name','email','phone','company','address']);
-    $stmt = $pdo->query('SELECT id, full_name, email, phone, company, address FROM customers ORDER BY id');
+    if($_SESSION['role'] === 'admin') {
+        $stmt = $pdo->query('SELECT id, full_name, email, phone, company, address FROM customers ORDER BY id');
+    } else {
+        $stmt = $pdo->prepare('SELECT id, full_name, email, phone, company, address FROM customers WHERE user_id=? ORDER BY id');
+        $stmt->execute([$_SESSION['user_id']]);
+    }
     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
         fputcsv($out, $row);
     }
@@ -28,25 +33,25 @@ if (isset($_POST['import']) && isset($_FILES['import_file']) && is_uploaded_file
             $email = trim($row['email'] ?? '');
             $id = $row['id'] ?? null;
             if ($id) {
-                $stmt = $pdo->prepare('SELECT id FROM customers WHERE id=?');
-                $stmt->execute([$id]);
+                $stmt = $pdo->prepare('SELECT id FROM customers WHERE id=? AND user_id=?');
+                $stmt->execute([$id, $_SESSION['user_id']]);
                 if ($stmt->fetchColumn()) {
-                    $u = $pdo->prepare('UPDATE customers SET full_name=?, email=?, phone=?, company=?, address=? WHERE id=?');
-                    $u->execute([$row['full_name'],$email,$row['phone'],$row['company'],$row['address'],$id]);
+                    $u = $pdo->prepare('UPDATE customers SET full_name=?, email=?, phone=?, company=?, address=? WHERE id=? AND user_id=?');
+                    $u->execute([$row['full_name'],$email,$row['phone'],$row['company'],$row['address'],$id,$_SESSION['user_id']]);
                     $count++; continue;
                 }
             }
             if ($email) {
-                $stmt = $pdo->prepare('SELECT id FROM customers WHERE email=?');
-                $stmt->execute([$email]);
+                $stmt = $pdo->prepare('SELECT id FROM customers WHERE email=? AND user_id=?');
+                $stmt->execute([$email, $_SESSION['user_id']]);
                 if ($cid = $stmt->fetchColumn()) {
-                    $u = $pdo->prepare('UPDATE customers SET full_name=?, phone=?, company=?, address=? WHERE id=?');
-                    $u->execute([$row['full_name'],$row['phone'],$row['company'],$row['address'],$cid]);
+                    $u = $pdo->prepare('UPDATE customers SET full_name=?, phone=?, company=?, address=? WHERE id=? AND user_id=?');
+                    $u->execute([$row['full_name'],$row['phone'],$row['company'],$row['address'],$cid,$_SESSION['user_id']]);
                     $count++; continue;
                 }
             }
-            $i = $pdo->prepare('INSERT INTO customers(full_name,email,phone,company,address) VALUES (?,?,?,?,?)');
-            $i->execute([$row['full_name'],$email,$row['phone'],$row['company'],$row['address']]);
+            $i = $pdo->prepare('INSERT INTO customers(full_name,email,phone,company,address,user_id) VALUES (?,?,?,?,?,?)');
+            $i->execute([$row['full_name'],$email,$row['phone'],$row['company'],$row['address'],$_SESSION['user_id']]);
             $count++;
         }
     }
@@ -64,15 +69,17 @@ if (!in_array($sort, $validSort)) {
     $sort = 'company';
 }
 $dir = strtolower($_GET['dir'] ?? 'asc') === 'desc' ? 'DESC' : 'ASC';
-
-$stmt = $pdo->prepare("SELECT c.*,
-    IFNULL(SUM(s.price_try * (1 + s.vat_rate/100)),0) -
-    IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.customer_id=c.id),0) AS balance
-    FROM customers c
-    LEFT JOIN services s ON s.customer_id = c.id
-    GROUP BY c.id
-    ORDER BY $sort $dir");
-$stmt->execute();
+$query = "SELECT c.*, IFNULL(SUM(s.price_try * (1 + s.vat_rate/100)),0) - IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.customer_id=c.id),0) AS balance FROM customers c LEFT JOIN services s ON s.customer_id = c.id";
+if($_SESSION['role'] !== 'admin') {
+    $query .= " WHERE c.user_id=:uid";
+}
+$query .= " GROUP BY c.id ORDER BY $sort $dir";
+$stmt = $pdo->prepare($query);
+if($_SESSION['role'] !== 'admin') {
+    $stmt->execute(['uid'=>$_SESSION['user_id']]);
+} else {
+    $stmt->execute();
+}
 $customers = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h1>Müşteriler</h1>

--- a/email_settings.php
+++ b/email_settings.php
@@ -5,25 +5,26 @@ require_once __DIR__.'/includes/functions.php';
 $keys = ['mail_logo','smtp_host','smtp_port','smtp_encryption','smtp_user','smtp_pass','smtp_from_name','smtp_from_email'];
 $settings=[];
 foreach($keys as $k){
-    $stmt=$pdo->prepare('SELECT value FROM settings WHERE `key`=?');
-    $stmt->execute([$k]);
+    $stmt=$pdo->prepare('SELECT value FROM settings WHERE `key`=? AND (user_id IS NULL OR user_id=?) ORDER BY user_id DESC LIMIT 1');
+    $stmt->execute([$k, $_SESSION['user_id']]);
     $settings[$k]=$stmt->fetchColumn() ?: '';
 }
 
 if($_SERVER['REQUEST_METHOD']==='POST'){
+    $uid = $_SESSION['role'] === 'admin' ? null : $_SESSION['user_id'];
     if(!empty($_FILES['mail_logo']['tmp_name'])){
         $dir='uploads';
         if(!is_dir($dir)) mkdir($dir,0777,true);
         $path=$dir.'/'.basename($_FILES['mail_logo']['name']);
         move_uploaded_file($_FILES['mail_logo']['tmp_name'],$path);
-        $stmt=$pdo->prepare("REPLACE INTO settings (`key`,value) VALUES ('mail_logo',?)");
-        $stmt->execute([$path]);
+        $stmt=$pdo->prepare("REPLACE INTO settings (`key`,user_id,value) VALUES ('mail_logo',?,?)");
+        $stmt->execute([$uid,$path]);
         $settings['mail_logo']=$path;
     }
     foreach(['smtp_host','smtp_port','smtp_encryption','smtp_user','smtp_pass','smtp_from_name','smtp_from_email'] as $k){
         if(isset($_POST[$k])){
-            $stmt=$pdo->prepare("REPLACE INTO settings (`key`,value) VALUES (?,?)");
-            $stmt->execute([$k,$_POST[$k]]);
+            $stmt=$pdo->prepare("REPLACE INTO settings (`key`,user_id,value) VALUES (?,?,?)");
+            $stmt->execute([$k,$uid,$_POST[$k]]);
             $settings[$k]=$_POST[$k];
         }
     }

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -11,4 +11,10 @@ if (!isset($_SESSION['user_id']) || (time() - ($_SESSION['last_active'] ?? 0) > 
 }
 
 $_SESSION['last_active'] = time();
+
+if (!isset($_SESSION['role'])) {
+    $stmt = $pdo->prepare('SELECT role FROM users WHERE id=?');
+    $stmt->execute([$_SESSION['user_id']]);
+    $_SESSION['role'] = $stmt->fetchColumn() ?: 'firma';
+}
 ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -24,10 +24,10 @@ function getUsdRate(PDO $pdo): float {
 function getEmailSettings(PDO $pdo): array {
     $defaults = include __DIR__ . '/../config/config.php';
     $settings = [];
-    $stmt = $pdo->prepare("SELECT `key`, value FROM settings WHERE `key` IN ('smtp_host','smtp_port','smtp_encryption','smtp_user','smtp_pass','smtp_from_name','smtp_from_email','mail_logo')");
-    $stmt->execute();
-    foreach($stmt->fetchAll(PDO::FETCH_KEY_PAIR) as $k=>$v){
-        $settings[$k] = $v;
+    $stmt = $pdo->prepare("SELECT `key`, value FROM settings WHERE `key` IN ('smtp_host','smtp_port','smtp_encryption','smtp_user','smtp_pass','smtp_from_name','smtp_from_email','mail_logo') AND (user_id IS NULL OR user_id=?) ORDER BY user_id");
+    $stmt->execute([$_SESSION['user_id'] ?? null]);
+    foreach($stmt->fetchAll(PDO::FETCH_ASSOC) as $row){
+        $settings[$row['key']] = $row['value'];
     }
     return [
         'host' => $settings['smtp_host'] ?? $defaults['smtp']['host'],

--- a/includes/header.php
+++ b/includes/header.php
@@ -11,8 +11,8 @@
 require_once __DIR__.'/functions.php';
 $settings = [];
 foreach (['logo','logo_header_width','logo_header_height'] as $k) {
-    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
-    $stmt->execute([$k]);
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=? AND (user_id IS NULL OR user_id=?) ORDER BY user_id DESC LIMIT 1');
+    $stmt->execute([$k, $_SESSION['user_id']]);
     $settings[$k] = $stmt->fetchColumn() ?: '';
 }
 $currentRate = getUsdRate($pdo);
@@ -40,7 +40,9 @@ $currentRate = getUsdRate($pdo);
       <ul class="dropdown-menu">
         <li><a class="dropdown-item" href="settings.php">Genel Ayarlar</a></li>
         <li><a class="dropdown-item" href="email_settings.php">E-posta Ayarları</a></li>
+        <?php if($_SESSION['role']==='admin'): ?>
         <li><a class="dropdown-item" href="users.php">Kullanıcılar</a></li>
+        <?php endif; ?>
       </ul>
     </li>
    </ul>

--- a/login.php
+++ b/login.php
@@ -9,11 +9,12 @@ if (isset($_SESSION['user_id']) && (time() - ($_SESSION['last_active'] ?? 0) < 1
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $stmt = $pdo->prepare('SELECT id, password FROM users WHERE email = ?');
+    $stmt = $pdo->prepare('SELECT id, password, role FROM users WHERE email = ?');
     $stmt->execute([$_POST['email']]);
     $user = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($user && password_verify($_POST['password'], $user['password'])) {
         $_SESSION['user_id'] = $user['id'];
+        $_SESSION['role'] = $user['role'];
         $_SESSION['last_active'] = time();
         header('Location: dashboard.php');
         exit;
@@ -24,7 +25,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $settings = [];
 foreach (['logo','logo_login_width','logo_login_height'] as $k) {
-    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=? AND user_id IS NULL');
     $stmt->execute([$k]);
     $settings[$k] = $stmt->fetchColumn() ?: '';
 }

--- a/products.php
+++ b/products.php
@@ -8,7 +8,12 @@ if (isset($_GET['export'])) {
     header('Content-Disposition: attachment; filename=products.csv');
     $out = fopen('php://output', 'w');
     fputcsv($out, ['id','name','unit','vat_rate','price','currency']);
-    $stmt = $pdo->query('SELECT id,name,unit,vat_rate,price,currency FROM products ORDER BY id');
+    if($_SESSION['role']==='admin') {
+        $stmt = $pdo->query('SELECT id,name,unit,vat_rate,price,currency FROM products ORDER BY id');
+    } else {
+        $stmt = $pdo->prepare('SELECT id,name,unit,vat_rate,price,currency FROM products WHERE user_id=? ORDER BY id');
+        $stmt->execute([$_SESSION['user_id']]);
+    }
     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
         fputcsv($out, $row);
     }
@@ -28,25 +33,25 @@ if (isset($_POST['import']) && isset($_FILES['import_file']) && is_uploaded_file
             $name = trim($row['name'] ?? '');
             $id = $row['id'] ?? null;
             if ($id) {
-                $stmt = $pdo->prepare('SELECT id FROM products WHERE id=?');
-                $stmt->execute([$id]);
+                $stmt = $pdo->prepare('SELECT id FROM products WHERE id=? AND user_id=?');
+                $stmt->execute([$id, $_SESSION['user_id']]);
                 if ($stmt->fetchColumn()) {
-                    $u = $pdo->prepare('UPDATE products SET name=?, unit=?, vat_rate=?, price=?, currency=? WHERE id=?');
-                    $u->execute([$row['name'],$row['unit'],$row['vat_rate'],$row['price'],$row['currency'],$id]);
+                    $u = $pdo->prepare('UPDATE products SET name=?, unit=?, vat_rate=?, price=?, currency=? WHERE id=? AND user_id=?');
+                    $u->execute([$row['name'],$row['unit'],$row['vat_rate'],$row['price'],$row['currency'],$id,$_SESSION['user_id']]);
                     $count++; continue;
                 }
             }
             if ($name) {
-                $stmt = $pdo->prepare('SELECT id FROM products WHERE name=?');
-                $stmt->execute([$name]);
+                $stmt = $pdo->prepare('SELECT id FROM products WHERE name=? AND user_id=?');
+                $stmt->execute([$name, $_SESSION['user_id']]);
                 if ($pid = $stmt->fetchColumn()) {
-                    $u = $pdo->prepare('UPDATE products SET unit=?, vat_rate=?, price=?, currency=? WHERE id=?');
-                    $u->execute([$row['unit'],$row['vat_rate'],$row['price'],$row['currency'],$pid]);
+                    $u = $pdo->prepare('UPDATE products SET unit=?, vat_rate=?, price=?, currency=? WHERE id=? AND user_id=?');
+                    $u->execute([$row['unit'],$row['vat_rate'],$row['price'],$row['currency'],$pid,$_SESSION['user_id']]);
                     $count++; continue;
                 }
             }
-            $i = $pdo->prepare('INSERT INTO products(name,unit,vat_rate,price,currency) VALUES (?,?,?,?,?)');
-            $i->execute([$row['name'],$row['unit'],$row['vat_rate'],$row['price'],$row['currency']]);
+            $i = $pdo->prepare('INSERT INTO products(name,unit,vat_rate,price,currency,user_id) VALUES (?,?,?,?,?,?)');
+            $i->execute([$row['name'],$row['unit'],$row['vat_rate'],$row['price'],$row['currency'],$_SESSION['user_id']]);
             $count++;
         }
     }
@@ -60,8 +65,14 @@ $action = $_GET['action'] ?? '';
 $id = $_GET['id'] ?? null;
 
 if ($action === 'delete' && $id) {
-    $stmt = $pdo->prepare('DELETE FROM products WHERE id=?');
-    $stmt->execute([$id]);
+    $sql = 'DELETE FROM products WHERE id=?';
+    $params = [$id];
+    if($_SESSION['role'] !== 'admin') {
+        $sql .= ' AND user_id=?';
+        $params[] = $_SESSION['user_id'];
+    }
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
     header('Location: products.php');
     exit;
 }
@@ -73,11 +84,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $price = $_POST['price'];
     $currency = $_POST['currency'];
     if ($action === 'edit' && $id) {
-        $stmt = $pdo->prepare('UPDATE products SET name=?, unit=?, vat_rate=?, price=?, currency=? WHERE id=?');
-        $stmt->execute([$name, $unit, $vat_rate, $price, $currency, $id]);
+        $sql = 'UPDATE products SET name=?, unit=?, vat_rate=?, price=?, currency=? WHERE id=?';
+        $params = [$name, $unit, $vat_rate, $price, $currency, $id];
+        if($_SESSION['role'] !== 'admin') {
+            $sql .= ' AND user_id=?';
+            $params[] = $_SESSION['user_id'];
+        }
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
     } else {
-        $stmt = $pdo->prepare('INSERT INTO products (name, unit, vat_rate, price, currency) VALUES (?, ?, ?, ?, ?)');
-        $stmt->execute([$name, $unit, $vat_rate, $price, $currency]);
+        $stmt = $pdo->prepare('INSERT INTO products (name, unit, vat_rate, price, currency, user_id) VALUES (?, ?, ?, ?, ?, ?)');
+        $stmt->execute([$name, $unit, $vat_rate, $price, $currency, $_SESSION['user_id']]);
     }
     header('Location: products.php');
     exit;
@@ -85,12 +102,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $edit = null;
 if ($action === 'edit' && $id) {
-    $stmt = $pdo->prepare('SELECT * FROM products WHERE id=?');
-    $stmt->execute([$id]);
+    $sql = 'SELECT * FROM products WHERE id=?';
+    $params = [$id];
+    if($_SESSION['role'] !== 'admin') {
+        $sql .= ' AND user_id=?';
+        $params[] = $_SESSION['user_id'];
+    }
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
     $edit = $stmt->fetch(PDO::FETCH_ASSOC);
 }
 
-$products = $pdo->query('SELECT * FROM products ORDER BY name ASC')->fetchAll(PDO::FETCH_ASSOC);
+if($_SESSION['role'] === 'admin') {
+    $products = $pdo->query('SELECT * FROM products ORDER BY name ASC')->fetchAll(PDO::FETCH_ASSOC);
+} else {
+    $stmt = $pdo->prepare('SELECT * FROM products WHERE user_id=? ORDER BY name ASC');
+    $stmt->execute([$_SESSION['user_id']]);
+    $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
 
 include __DIR__ . '/includes/header.php';
 ?>

--- a/provider.php
+++ b/provider.php
@@ -2,20 +2,39 @@
 require __DIR__.'/includes/auth.php';
 require __DIR__.'/includes/functions.php';
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$stmt = $pdo->prepare('SELECT * FROM providers WHERE id=?');
-$stmt->execute([$id]);
+$sql = 'SELECT * FROM providers WHERE id=?';
+$params = [$id];
+if($_SESSION['role'] !== 'admin') {
+    $sql .= ' AND user_id=?';
+    $params[] = $_SESSION['user_id'];
+}
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
 $provider = $stmt->fetch(PDO::FETCH_ASSOC);
 if(!$provider){
     header('Location: providers.php');
     exit;
 }
 $usdRate = getUsdRate($pdo);
-$totPurch = (float)$pdo->query("SELECT SUM(price_try) FROM provider_purchases WHERE provider_id={$id}")->fetchColumn();
-$totPay = (float)$pdo->query("SELECT SUM(amount_try) FROM provider_payments WHERE provider_id={$id}")->fetchColumn();
+if($_SESSION['role'] === 'admin') {
+    $stmtTmp = $pdo->prepare("SELECT SUM(price_try) FROM provider_purchases WHERE provider_id=?");
+    $stmtTmp->execute([$id]);
+    $totPurch = (float)$stmtTmp->fetchColumn();
+    $stmtTmp = $pdo->prepare("SELECT SUM(amount_try) FROM provider_payments WHERE provider_id=?");
+    $stmtTmp->execute([$id]);
+    $totPay = (float)$stmtTmp->fetchColumn();
+} else {
+    $stmtTmp = $pdo->prepare("SELECT SUM(price_try) FROM provider_purchases WHERE provider_id=? AND user_id=?");
+    $stmtTmp->execute([$id, $_SESSION['user_id']]);
+    $totPurch = (float)$stmtTmp->fetchColumn();
+    $stmtTmp = $pdo->prepare("SELECT SUM(amount_try) FROM provider_payments WHERE provider_id=? AND user_id=?");
+    $stmtTmp->execute([$id, $_SESSION['user_id']]);
+    $totPay = (float)$stmtTmp->fetchColumn();
+}
 $balance = $totPurch - $totPay;
 if($balance < 0) $balance = 0;
 if($_SERVER['REQUEST_METHOD']==='POST' && !empty($_POST['item_name'])){
-$ins = $pdo->prepare('INSERT INTO provider_purchases(provider_id,item_name,quantity,unit,unit_price,vat_rate,currency,purchase_date,payment_date,price_try,notes) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
+$ins = $pdo->prepare('INSERT INTO provider_purchases(provider_id,item_name,quantity,unit,unit_price,vat_rate,currency,purchase_date,payment_date,price_try,notes,user_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)');
     foreach($_POST['item_name'] as $i=>$name){
         if(trim($name)=='') continue;
         $qty = (int)($_POST['quantity'][$i] ?? 1);
@@ -28,17 +47,17 @@ $ins = $pdo->prepare('INSERT INTO provider_purchases(provider_id,item_name,quant
         $line = $qty*$price;
         $lineVat = $line*$vat/100;
         $try = $cur==='USD' ? ($line+$lineVat)*$usdRate : ($line+$lineVat);
-        $ins->execute([$id,$name,$qty,$unit,$price,$vat,$cur,$pdate,$paydate,$try,$_POST['notes'][$i] ?? '']);
+        $ins->execute([$id,$name,$qty,$unit,$price,$vat,$cur,$pdate,$paydate,$try,$_POST['notes'][$i] ?? '',$_SESSION['user_id']]);
     }
     $_SESSION['message']='Satın alım kaydedildi';
     header('Location: provider.php?id='.$id);
     exit;
 }
-$purchasesStmt = $pdo->prepare('SELECT * FROM provider_purchases WHERE provider_id=? ORDER BY purchase_date DESC');
-$purchasesStmt->execute([$id]);
+$purchasesStmt = $pdo->prepare($_SESSION['role']==='admin' ? 'SELECT * FROM provider_purchases WHERE provider_id=? ORDER BY purchase_date DESC' : 'SELECT * FROM provider_purchases WHERE provider_id=? AND user_id=? ORDER BY purchase_date DESC');
+$purchasesStmt->execute($_SESSION['role']==='admin' ? [$id] : [$id, $_SESSION['user_id']]);
 $purchases = $purchasesStmt->fetchAll(PDO::FETCH_ASSOC);
-$payStmt = $pdo->prepare('SELECT * FROM provider_payments WHERE provider_id=? ORDER BY pay_date DESC');
-$payStmt->execute([$id]);
+$payStmt = $pdo->prepare($_SESSION['role']==='admin' ? 'SELECT * FROM provider_payments WHERE provider_id=? ORDER BY pay_date DESC' : 'SELECT * FROM provider_payments WHERE provider_id=? AND user_id=? ORDER BY pay_date DESC');
+$payStmt->execute($_SESSION['role']==='admin' ? [$id] : [$id, $_SESSION['user_id']]);
 $payments = $payStmt->fetchAll(PDO::FETCH_ASSOC);
 include __DIR__.'/includes/header.php';
 ?>

--- a/providers.php
+++ b/providers.php
@@ -5,8 +5,14 @@ $action = $_GET['action'] ?? '';
 $id = $_GET['id'] ?? null;
 
 if ($action === 'delete' && $id) {
-    $stmt = $pdo->prepare('DELETE FROM providers WHERE id=?');
-    $stmt->execute([$id]);
+    $sql = 'DELETE FROM providers WHERE id=?';
+    $params = [$id];
+    if($_SESSION['role'] !== 'admin') {
+        $sql .= ' AND user_id=?';
+        $params[] = $_SESSION['user_id'];
+    }
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
     header('Location: providers.php');
     exit;
 }
@@ -15,11 +21,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $name = $_POST['name'];
     $website = $_POST['website'];
     if ($action === 'edit' && $id) {
-        $stmt = $pdo->prepare('UPDATE providers SET name=?, website=? WHERE id=?');
-        $stmt->execute([$name, $website, $id]);
+        $sql = 'UPDATE providers SET name=?, website=? WHERE id=?';
+        $params = [$name, $website, $id];
+        if($_SESSION['role'] !== 'admin') {
+            $sql .= ' AND user_id=?';
+            $params[] = $_SESSION['user_id'];
+        }
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
     } else {
-        $stmt = $pdo->prepare('INSERT INTO providers (name, website) VALUES (?, ?)');
-        $stmt->execute([$name, $website]);
+        $stmt = $pdo->prepare('INSERT INTO providers (name, website, user_id) VALUES (?, ?, ?)');
+        $stmt->execute([$name, $website, $_SESSION['user_id']]);
     }
     header('Location: providers.php');
     exit;
@@ -27,12 +39,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $edit = null;
 if ($action === 'edit' && $id) {
-    $stmt = $pdo->prepare('SELECT * FROM providers WHERE id=?');
-    $stmt->execute([$id]);
+    $sql = 'SELECT * FROM providers WHERE id=?';
+    $params = [$id];
+    if($_SESSION['role'] !== 'admin') {
+        $sql .= ' AND user_id=?';
+        $params[] = $_SESSION['user_id'];
+    }
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
     $edit = $stmt->fetch(PDO::FETCH_ASSOC);
 }
 
-$stmt = $pdo->query('SELECT p.*, (SELECT IFNULL(SUM(price_try),0) FROM provider_purchases WHERE provider_id=p.id) - (SELECT IFNULL(SUM(amount_try),0) FROM provider_payments WHERE provider_id=p.id) AS total_due FROM providers p ORDER BY p.id DESC');
+if($_SESSION['role'] === 'admin') {
+    $stmt = $pdo->query('SELECT p.*, (SELECT IFNULL(SUM(price_try),0) FROM provider_purchases WHERE provider_id=p.id) - (SELECT IFNULL(SUM(amount_try),0) FROM provider_payments WHERE provider_id=p.id) AS total_due FROM providers p ORDER BY p.id DESC');
+} else {
+    $stmt = $pdo->prepare('SELECT p.*, (SELECT IFNULL(SUM(price_try),0) FROM provider_purchases WHERE provider_id=p.id AND user_id=?) - (SELECT IFNULL(SUM(amount_try),0) FROM provider_payments WHERE provider_id=p.id AND user_id=?) AS total_due FROM providers p WHERE p.user_id=? ORDER BY p.id DESC');
+    $stmt->execute([$_SESSION['user_id'], $_SESSION['user_id'], $_SESSION['user_id']]);
+}
 $providers = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 include __DIR__ . '/includes/header.php';

--- a/settings.php
+++ b/settings.php
@@ -2,38 +2,43 @@
 require __DIR__ . '/includes/auth.php';
 
 $settings = [];
-$keys = ['logo','logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height'];
+$keys = ['logo','logo_login_width','logo_login_height','logo_header_width','logo_header_height'];
+if ($_SESSION['role'] === 'admin') {
+    $keys = array_merge($keys, ['footer_text','footer_logo','footer_logo_width','footer_logo_height']);
+}
 foreach ($keys as $k) {
-    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
-    $stmt->execute([$k]);
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=? AND (user_id IS NULL OR user_id=?) ORDER BY user_id DESC LIMIT 1');
+    $stmt->execute([$k, $_SESSION['user_id']]);
     $settings[$k] = $stmt->fetchColumn() ?: '';
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $save_message = '';
+    $uid = $_SESSION['role'] === 'admin' ? null : $_SESSION['user_id'];
     if (!empty($_FILES['logo']['tmp_name'])) {
         $dir = 'uploads';
         if (!is_dir($dir)) mkdir($dir, 0777, true);
         $path = $dir . '/' . basename($_FILES['logo']['name']);
         move_uploaded_file($_FILES['logo']['tmp_name'], $path);
-        $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES ('logo', ?)");
-        $stmt->execute([$path]);
+        $stmt = $pdo->prepare("REPLACE INTO settings (`key`, user_id, value) VALUES ('logo', ?, ?)");
+        $stmt->execute([$uid, $path]);
         $settings['logo'] = $path;
     }
-    if(!empty($_FILES['footer_logo']['tmp_name'])){
+    if($_SESSION['role']==='admin' && !empty($_FILES['footer_logo']['tmp_name'])){
         $dir = 'uploads';
         if(!is_dir($dir)) mkdir($dir,0777,true);
         $path = $dir.'/'.basename($_FILES['footer_logo']['name']);
         move_uploaded_file($_FILES['footer_logo']['tmp_name'],$path);
-        $stmt = $pdo->prepare("REPLACE INTO settings (`key`,value) VALUES ('footer_logo',?)");
+        $stmt = $pdo->prepare("REPLACE INTO settings (`key`,user_id,value) VALUES ('footer_logo',NULL,?)");
         $stmt->execute([$path]);
         $settings['footer_logo']=$path;
     }
-    foreach (['logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height'] as $k) {
+    foreach ($keys as $k) {
         if (isset($_POST[$k])) {
-            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES (?, ?)");
-            $stmt->execute([$k, $_POST[$k]]);
-            $settings[$k] = $_POST[$k];
+            $val = $_POST[$k];
+            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, user_id, value) VALUES (?, ?, ?)");
+            $stmt->execute([$k, $k==='footer_text'||$k==='footer_logo'||$k==='footer_logo_width'||$k==='footer_logo_height'?NULL:$uid, $val]);
+            $settings[$k] = $val;
         }
     }
     $save_message = 'Ayarlar kaydedildi';
@@ -69,6 +74,7 @@ include __DIR__ . '/includes/header.php';
       <label class="form-label">Header Logo Yükseklik</label>
       <input type="number" name="logo_header_height" class="form-control" value="<?= htmlspecialchars($settings['logo_header_height']) ?>">
     </div>
+    <?php if($_SESSION['role']==='admin'): ?>
     <div class="col-md-6 mb-3">
       <label class="form-label">Footer Yazısı</label>
       <input type="text" name="footer_text" class="form-control" value="<?= htmlspecialchars($settings['footer_text']) ?>">
@@ -88,6 +94,7 @@ include __DIR__ . '/includes/header.php';
       <label class="form-label">Footer Logo Yükseklik</label>
       <input type="number" name="footer_logo_height" class="form-control" value="<?= htmlspecialchars($settings['footer_logo_height']) ?>">
     </div>
+    <?php endif; ?>
   </div>
   <button type="submit" class="btn btn-primary">Kaydet</button>
 </form>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -5,7 +5,9 @@ CREATE TABLE customers (
   phone VARCHAR(50),
   company VARCHAR(255),
   address TEXT,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  user_id INT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE products (
@@ -15,14 +17,18 @@ CREATE TABLE products (
   vat_rate DECIMAL(5,2),
   price DECIMAL(10,2),
   currency VARCHAR(10),
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  user_id INT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE providers (
   id INT AUTO_INCREMENT PRIMARY KEY,
   name VARCHAR(255),
   website VARCHAR(255),
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  user_id INT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE services (
@@ -44,10 +50,12 @@ CREATE TABLE services (
   notes TEXT,
   reminder_enabled TINYINT(1) DEFAULT 0,
   reminder_days VARCHAR(50),
+  user_id INT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE,
   FOREIGN KEY (product_id) REFERENCES products(id),
-  FOREIGN KEY (provider_id) REFERENCES providers(id)
+  FOREIGN KEY (provider_id) REFERENCES providers(id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE service_items (
@@ -61,9 +69,11 @@ CREATE TABLE service_items (
   currency VARCHAR(10),
   provider_id INT,
   description TEXT,
+  user_id INT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE,
-  FOREIGN KEY (provider_id) REFERENCES providers(id)
+  FOREIGN KEY (provider_id) REFERENCES providers(id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE exchange_rates (
@@ -80,22 +90,27 @@ CREATE TABLE payments (
   amount_try DECIMAL(10,2),
   amount_orig DECIMAL(10,2),
   currency VARCHAR(10),
+  user_id INT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE,
-  FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE SET NULL
+  FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE users (
   id INT AUTO_INCREMENT PRIMARY KEY,
   email VARCHAR(100) UNIQUE,
   password VARCHAR(255),
-  role ENUM('admin','user') DEFAULT 'admin',
+  role ENUM('admin','firma') DEFAULT 'firma',
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE settings (
-  `key` VARCHAR(50) PRIMARY KEY,
-  value TEXT
+  `key` VARCHAR(50),
+  user_id INT DEFAULT NULL,
+  value TEXT,
+  PRIMARY KEY (`key`, user_id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE provider_purchases (
@@ -111,8 +126,10 @@ CREATE TABLE provider_purchases (
   payment_date DATE,
   price_try DECIMAL(10,2),
   notes TEXT,
+  user_id INT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE email_logs (
@@ -135,28 +152,31 @@ CREATE TABLE provider_payments (
   currency VARCHAR(10),
   pay_date DATE,
   notes TEXT,
+  user_id INT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE
+  FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO users (email, password, role) VALUES
-('info@precadmedya.com.tr', '$2y$12$g0QsFECHVjIwr2WhxPLLV.i/wskHA2S0VuZY0bowUph3KdXmaZ3MS', 'admin');
+('info@precadmedya.com.tr', '$2y$12$g0QsFECHVjIwr2WhxPLLV.i/wskHA2S0VuZY0bowUph3KdXmaZ3MS', 'admin'),
+('firma@example.com', '$2y$12$0mKHcB3Ojp2tGv2OnraYTekBClyuyx9ObpzUGqSnLeFLKbhECbp2.', 'firma');
 
-INSERT INTO settings (`key`, value) VALUES
-('logo', ''),
-('logo_login_width','140'),
-('logo_login_height','40'),
-('logo_header_width','120'),
-('logo_header_height','40'),
-('mail_logo',''),
-('smtp_host','smtp.yandex.com.tr'),
-('smtp_port','465'),
-('smtp_encryption','ssl'),
-('smtp_user','info@precadmedya.com.tr'),
-('smtp_pass','Precadmedya34523'),
-('smtp_from_name','Precad Medya'),
-('smtp_from_email','info@precadmedya.com.tr'),
-('footer_text','Precad Medya 2025 Tüm Hakları Saklıdır.'),
-('footer_logo',''),
-('footer_logo_width','120'),
-('footer_logo_height','40');
+INSERT INTO settings (`key`, user_id, value) VALUES
+('logo', NULL, ''),
+('logo_login_width', NULL, '140'),
+('logo_login_height', NULL, '40'),
+('logo_header_width', NULL, '120'),
+('logo_header_height', NULL, '40'),
+('mail_logo', NULL, ''),
+('smtp_host', NULL, 'smtp.yandex.com.tr'),
+('smtp_port', NULL, '465'),
+('smtp_encryption', NULL, 'ssl'),
+('smtp_user', NULL, 'info@precadmedya.com.tr'),
+('smtp_pass', NULL, 'Precadmedya34523'),
+('smtp_from_name', NULL, 'Precad Medya'),
+('smtp_from_email', NULL, 'info@precadmedya.com.tr'),
+('footer_text', NULL, 'Precad Medya 2025 Tüm Hakları Saklıdır.'),
+('footer_logo', NULL, ''),
+('footer_logo_width', NULL, '120'),
+('footer_logo_height', NULL, '40');

--- a/users.php
+++ b/users.php
@@ -1,5 +1,9 @@
 <?php
 require __DIR__ . '/includes/auth.php';
+if($_SESSION['role'] !== 'admin') {
+    header('Location: dashboard.php');
+    exit;
+}
 
 $action = $_GET['action'] ?? '';
 $id = $_GET['id'] ?? null;
@@ -82,7 +86,7 @@ include __DIR__ . '/includes/header.php';
     <label class="form-label">Rol</label>
     <select name="role" class="form-control">
       <option value="admin" <?= isset($editUser) && $editUser['role']==='admin' ? 'selected' : '' ?>>Admin</option>
-      <option value="user" <?= isset($editUser) && $editUser['role']==='user' ? 'selected' : '' ?>>User</option>
+      <option value="firma" <?= isset($editUser) && $editUser['role']==='firma' ? 'selected' : '' ?>>Firma</option>
     </select>
   </div>
   <button type="submit" class="btn btn-primary">Kaydet</button>


### PR DESCRIPTION
## Summary
- Add company-specific data ownership by adding `user_id` to major tables and seeding example firm user
- Store user roles in session and tailor navigation/settings per role
- Restrict data operations (customers, products, providers) to owning firm and guard admin-only pages

## Testing
- `php -l login.php`
- `php -l includes/auth.php`
- `php -l includes/header.php`
- `php -l includes/functions.php`
- `php -l settings.php`
- `php -l email_settings.php`
- `php -l users.php`
- `php -l customers.php`
- `php -l customer_add.php`
- `php -l customer_edit.php`
- `php -l customer_delete.php`
- `php -l customer.php`
- `php -l products.php`
- `php -l providers.php`
- `php -l provider.php`


------
https://chatgpt.com/codex/tasks/task_e_689f2f79a4ec8333892fc0eb15b9c7ae