### PR TITLE
Add configurable PNG favicon

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -1,3 +1,13 @@
+<?php
+require_once __DIR__.'/functions.php';
+$settings = [];
+foreach (['logo','logo_header_width','logo_header_height','favicon'] as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt->execute([$k]);
+    $settings[$k] = $stmt->fetchColumn() ?: '';
+}
+$currentRate = getUsdRate($pdo);
+?>
 <!DOCTYPE html>
 <html lang="tr">
 <head>
@@ -5,18 +15,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Takip Sistemi</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<?php if ($settings['favicon']): ?>
+<link rel="icon" type="image/png" href="/<?= htmlspecialchars($settings['favicon']) ?>">
+<?php endif; ?>
 </head>
 <body>
-<?php
-require_once __DIR__.'/functions.php';
-$settings = [];
-foreach (['logo','logo_header_width','logo_header_height'] as $k) {
-    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
-    $stmt->execute([$k]);
-    $settings[$k] = $stmt->fetchColumn() ?: '';
-}
-$currentRate = getUsdRate($pdo);
-?>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
  <div class="container-fluid">
   <a class="navbar-brand me-3" href="dashboard.php">

--- a/login.php
+++ b/login.php
@@ -23,7 +23,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $settings = [];
-foreach (['logo','logo_login_width','logo_login_height'] as $k) {
+foreach (['logo','logo_login_width','logo_login_height','favicon'] as $k) {
     $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
     $stmt->execute([$k]);
     $settings[$k] = $stmt->fetchColumn() ?: '';
@@ -37,6 +37,9 @@ foreach (['logo','logo_login_width','logo_login_height'] as $k) {
 <title>Giriş Yap</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap" rel="stylesheet">
+<?php if ($settings['favicon']): ?>
+<link rel="icon" type="image/png" href="/<?= htmlspecialchars($settings['favicon']) ?>">
+<?php endif; ?>
 <style>
 body {background: linear-gradient(135deg, #f0f4f8, #d9e2ec); font-family: 'Poppins', sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;}
 .login-box {background: #fff; padding: 40px; border-radius: 16px; box-shadow: 0 10px 40px rgba(0,0,0,0.1); width: 100%; max-width: 400px; text-align: center;}

--- a/settings.php
+++ b/settings.php
@@ -2,7 +2,7 @@
 require __DIR__ . '/includes/auth.php';
 
 $settings = [];
-$keys = ['logo','logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height'];
+$keys = ['logo','logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height','favicon'];
 foreach ($keys as $k) {
     $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
     $stmt->execute([$k]);
@@ -29,6 +29,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt->execute([$path]);
         $settings['footer_logo']=$path;
     }
+    if (!empty($_FILES['favicon']['tmp_name'])) {
+        $ext = strtolower(pathinfo($_FILES['favicon']['name'], PATHINFO_EXTENSION));
+        if ($ext === 'png') {
+            $dir = 'uploads';
+            if (!is_dir($dir)) mkdir($dir, 0777, true);
+            $path = $dir . '/' . basename($_FILES['favicon']['name']);
+            move_uploaded_file($_FILES['favicon']['tmp_name'], $path);
+            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES ('favicon', ?)");
+            $stmt->execute([$path]);
+            $settings['favicon'] = $path;
+        }
+    }
     foreach (['logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height'] as $k) {
         if (isset($_POST[$k])) {
             $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES (?, ?)");
@@ -50,6 +62,15 @@ include __DIR__ . '/includes/header.php';
   <?php if ($settings['logo']): ?>
   <div class="mb-3">
     <img src="/<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" style="max-width:200px;">
+  </div>
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Favicon (PNG)</label>
+    <input type="file" name="favicon" class="form-control" accept="image/png">
+  </div>
+  <?php if ($settings['favicon']): ?>
+  <div class="mb-3">
+    <img src="/<?= htmlspecialchars($settings['favicon']) ?>" alt="Favicon" style="width:32px;height:32px;">
   </div>
   <?php endif; ?>
   <div class="row">

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -148,6 +148,7 @@ INSERT INTO settings (`key`, value) VALUES
 ('logo_login_height','40'),
 ('logo_header_width','120'),
 ('logo_header_height','40'),
+('favicon',''),
 ('mail_logo',''),
 ('smtp_host','smtp.yandex.com.tr'),
 ('smtp_port','465'),


### PR DESCRIPTION
## Summary
- allow uploading a PNG favicon in general settings and store it in database
- load and display favicon on all pages via header and login templates
- seed schema with default favicon setting

## Testing
- `php -l settings.php && php -l includes/header.php && php -l login.php && php -l sql/schema.sql`

------
https://chatgpt.com/codex/tasks/task_e_68b43b1c149c8333bdf1e58f0d22005d