### PR TITLE
Add configurable login logo support

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -10,18 +10,31 @@
 <?php
 require_once __DIR__.'/functions.php';
 $settings = [];
-foreach (['logo','logo_header_width','logo_header_height'] as $k) {
-    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+foreach (['logo', 'logo_header_width', 'logo_header_height'] as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key` = ?');
     $stmt->execute([$k]);
     $settings[$k] = $stmt->fetchColumn() ?: '';
 }
+$headerLogoWidth = isset($settings['logo_header_width']) ? (int)$settings['logo_header_width'] : 0;
+$headerLogoHeight = isset($settings['logo_header_height']) ? (int)$settings['logo_header_height'] : 0;
+$headerLogoStyleParts = ['max-width:160px'];
+if ($headerLogoWidth > 0) {
+    $headerLogoStyleParts[] = 'width:' . $headerLogoWidth . 'px';
+}
+if ($headerLogoHeight > 0) {
+    $headerLogoStyleParts[] = 'height:' . $headerLogoHeight . 'px';
+} else {
+    $headerLogoStyleParts[] = 'height:auto';
+}
+$headerLogoStyleParts[] = 'object-fit:contain';
+$headerLogoStyle = implode(';', $headerLogoStyleParts);
 $currentRate = getUsdRate($pdo);
 ?>
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
  <div class="container-fluid">
   <a class="navbar-brand me-3" href="dashboard.php">
     <?php if ($settings['logo']): ?>
-      <img src="<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" style="width:<?= (int)$settings['logo_header_width'] ?>px;height:<?= (int)$settings['logo_header_height'] ?>px;object-fit:contain;">
+      <img src="<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" style="<?= htmlspecialchars($headerLogoStyle, ENT_QUOTES) ?>">
     <?php else: ?>Takip Sistemi<?php endif; ?>
   </a>
   <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/login.php
+++ b/login.php
@@ -23,11 +23,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $settings = [];
-foreach (['logo','logo_login_width','logo_login_height'] as $k) {
-    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+foreach (['logo', 'logo_login_width', 'logo_login_height'] as $k) {
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key` = ?');
     $stmt->execute([$k]);
     $settings[$k] = $stmt->fetchColumn() ?: '';
 }
+
+$logoWidth = isset($settings['logo_login_width']) ? (int)$settings['logo_login_width'] : 0;
+$logoHeight = isset($settings['logo_login_height']) ? (int)$settings['logo_login_height'] : 0;
+$logoStyleParts = ['max-width:100%'];
+if ($logoWidth > 0) {
+    $logoStyleParts[] = 'width:' . $logoWidth . 'px';
+}
+if ($logoHeight > 0) {
+    $logoStyleParts[] = 'height:' . $logoHeight . 'px';
+} else {
+    $logoStyleParts[] = 'height:auto';
+}
+$logoStyleParts[] = 'object-fit:contain';
+$logoStyle = implode(';', $logoStyleParts);
 ?>
 <!DOCTYPE html>
 <html lang="tr">
@@ -40,13 +54,13 @@ foreach (['logo','logo_login_width','logo_login_height'] as $k) {
 <style>
 body {background: linear-gradient(135deg, #f0f4f8, #d9e2ec); font-family: 'Poppins', sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;}
 .login-box {background: #fff; padding: 40px; border-radius: 16px; box-shadow: 0 10px 40px rgba(0,0,0,0.1); width: 100%; max-width: 400px; text-align: center;}
-.login-logo img {margin-bottom: 20px; width:<?= (int)$settings['logo_login_width'] ?>px; height:<?= (int)$settings['logo_login_height'] ?>px; object-fit:contain;}
+.login-logo img {margin-bottom: 20px;}
 </style>
 </head>
 <body>
 <div class="login-box">
   <div class="login-logo">
-    <?php if ($settings['logo']): ?><img src="<?= htmlspecialchars($settings['logo']) ?>" alt="Logo"><?php endif; ?>
+    <?php if ($settings['logo']): ?><img src="<?= htmlspecialchars($settings['logo']) ?>" alt="Logo" style="<?= htmlspecialchars($logoStyle, ENT_QUOTES) ?>"><?php endif; ?>
   </div>
   <?php if ($error): ?><div class="alert alert-danger"><?= $error ?></div><?php endif; ?>
   <form method="post">

--- a/settings.php
+++ b/settings.php
@@ -2,9 +2,9 @@
 require __DIR__ . '/includes/auth.php';
 
 $settings = [];
-$keys = ['logo','logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height'];
+$keys = ['logo', 'logo_login_width', 'logo_login_height', 'logo_header_width', 'logo_header_height', 'footer_text', 'footer_logo', 'footer_logo_width', 'footer_logo_height'];
 foreach ($keys as $k) {
-    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key`=?');
+    $stmt = $pdo->prepare('SELECT value FROM settings WHERE `key` = ?');
     $stmt->execute([$k]);
     $settings[$k] = $stmt->fetchColumn() ?: '';
 }
@@ -13,28 +13,51 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $save_message = '';
     if (!empty($_FILES['logo']['tmp_name'])) {
         $dir = 'uploads';
-        if (!is_dir($dir)) mkdir($dir, 0777, true);
-        $path = $dir . '/' . basename($_FILES['logo']['name']);
-        move_uploaded_file($_FILES['logo']['tmp_name'], $path);
-        $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES ('logo', ?)");
-        $stmt->execute([$path]);
-        $settings['logo'] = $path;
-    }
-    if(!empty($_FILES['footer_logo']['tmp_name'])){
-        $dir = 'uploads';
-        if(!is_dir($dir)) mkdir($dir,0777,true);
-        $path = $dir.'/'.basename($_FILES['footer_logo']['name']);
-        move_uploaded_file($_FILES['footer_logo']['tmp_name'],$path);
-        $stmt = $pdo->prepare("REPLACE INTO settings (`key`,value) VALUES ('footer_logo',?)");
-        $stmt->execute([$path]);
-        $settings['footer_logo']=$path;
-    }
-    foreach (['logo_login_width','logo_login_height','logo_header_width','logo_header_height','footer_text','footer_logo','footer_logo_width','footer_logo_height'] as $k) {
-        if (isset($_POST[$k])) {
-            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES (?, ?)");
-            $stmt->execute([$k, $_POST[$k]]);
-            $settings[$k] = $_POST[$k];
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
         }
+        $extension = strtolower(pathinfo($_FILES['logo']['name'], PATHINFO_EXTENSION));
+        $unique = str_replace('.', '_', uniqid('logo_', true));
+        $filename = $unique . ($extension ? '.' . $extension : '');
+        $path = $dir . '/' . $filename;
+        if (move_uploaded_file($_FILES['logo']['tmp_name'], $path)) {
+            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES ('logo', ?)");
+            $stmt->execute([$path]);
+            $settings['logo'] = $path;
+        }
+    }
+    if (!empty($_FILES['footer_logo']['tmp_name'])) {
+        $dir = 'uploads';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $extension = strtolower(pathinfo($_FILES['footer_logo']['name'], PATHINFO_EXTENSION));
+        $unique = str_replace('.', '_', uniqid('footer_logo_', true));
+        $filename = $unique . ($extension ? '.' . $extension : '');
+        $path = $dir . '/' . $filename;
+        if (move_uploaded_file($_FILES['footer_logo']['tmp_name'], $path)) {
+            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES ('footer_logo', ?)");
+            $stmt->execute([$path]);
+            $settings['footer_logo'] = $path;
+        }
+    }
+
+    $numericKeys = ['logo_login_width', 'logo_login_height', 'logo_header_width', 'logo_header_height', 'footer_logo_width', 'footer_logo_height'];
+    foreach ($numericKeys as $k) {
+        if (array_key_exists($k, $_POST)) {
+            $value = trim((string)$_POST[$k]);
+            $value = $value === '' ? '' : max(0, (int)$value);
+            $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES (?, ?)");
+            $stmt->execute([$k, $value]);
+            $settings[$k] = $value;
+        }
+    }
+
+    if (isset($_POST['footer_text'])) {
+        $value = trim((string)$_POST['footer_text']);
+        $stmt = $pdo->prepare("REPLACE INTO settings (`key`, value) VALUES ('footer_text', ?)");
+        $stmt->execute([$value]);
+        $settings['footer_text'] = $value;
     }
     $save_message = 'Ayarlar kaydedildi';
 }


### PR DESCRIPTION
## Summary
- display the configurable logo on the login form with adjustable dimensions
- enhance the settings page to manage logo uploads and size constraints safely
- reuse the sizing helpers for the header logo so empty settings no longer hide it

## Testing
- php -l login.php
- php -l settings.php
- php -l includes/header.php

------
https://chatgpt.com/codex/tasks/task_e_68f68c49c7d88333a93edad5cb744632