### PR TITLE
Fix customer AJAX sorting behaviour

### DIFF
--- a/ajax/customers_search.php
+++ b/ajax/customers_search.php
@@ -1,0 +1,56 @@
+<?php
+require __DIR__.'/../includes/auth.php';
+require __DIR__.'/../includes/functions.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$validSort = ['company','balance','full_name','email','phone','created_at','id'];
+$sort = $_GET['sort'] ?? 'company';
+if (!in_array($sort, $validSort, true)) {
+    $sort = 'company';
+}
+$dir = strtolower($_GET['dir'] ?? 'asc') === 'desc' ? 'DESC' : 'ASC';
+
+$q = trim($_GET['q'] ?? '');
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 200;
+if ($limit < 1 || $limit > 500) {
+    $limit = 200;
+}
+
+$params = [];
+$where = '';
+if ($q !== '') {
+    $like = '%'.$q.'%';
+    $params[':search'] = $like;
+    $where = "WHERE c.full_name LIKE :search OR c.email LIKE :search OR c.phone LIKE :search OR c.company LIKE :search OR c.address LIKE :search OR CAST(c.id AS CHAR) LIKE :search";
+}
+
+$sql = "SELECT c.*, IFNULL(SUM(s.price_try * (1 + s.vat_rate/100)),0) - IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.customer_id=c.id),0) AS balance
+        FROM customers c
+        LEFT JOIN services s ON s.customer_id = c.id
+        $where
+        GROUP BY c.id
+        ORDER BY $sort $dir
+        LIMIT $limit";
+
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$customers = [];
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $customers[] = [
+        'id' => (int)$row['id'],
+        'full_name' => $row['full_name'],
+        'email' => $row['email'],
+        'phone' => $row['phone'],
+        'company' => $row['company'],
+        'address' => $row['address'],
+        'balance' => (float)$row['balance'],
+        'balance_formatted' => number_format((float)$row['balance'], 2, ',', '.').' ₺',
+        'created_at' => $row['created_at'],
+        'created_at_formatted' => $row['created_at'] ? date('d.m.Y', strtotime($row['created_at'])) : '',
+    ];
+}
+
+echo json_encode([
+    'customers' => $customers,
+]);

--- a/ajax/services_search.php
+++ b/ajax/services_search.php
@@ -1,0 +1,58 @@
+<?php
+require __DIR__.'/../includes/auth.php';
+require __DIR__.'/../includes/functions.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$q = trim($_GET['q'] ?? '');
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 200;
+if ($limit < 1 || $limit > 500) {
+    $limit = 200;
+}
+
+$params = [];
+$where = '';
+if ($q !== '') {
+    $like = '%'.$q.'%';
+    $params[':search'] = $like;
+    $where = "WHERE s.service_type LIKE :search OR s.site_name LIKE :search OR s.status LIKE :search OR s.notes LIKE :search OR c.full_name LIKE :search OR CAST(s.id AS CHAR) LIKE :search";
+}
+
+$sql = "SELECT s.*, c.full_name
+        FROM services s
+        JOIN customers c ON s.customer_id = c.id
+        $where
+        ORDER BY s.id DESC
+        LIMIT $limit";
+
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$services = [];
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $total = (float)$row['price_try'] * (1 + ((float)$row['vat_rate'])/100);
+    $services[] = [
+        'id' => (int)$row['id'],
+        'full_name' => $row['full_name'],
+        'service_type' => $row['service_type'],
+        'site_name' => $row['site_name'],
+        'start_date' => $row['start_date'],
+        'start_date_formatted' => $row['start_date'] ? date('d.m.Y', strtotime($row['start_date'])) : '',
+        'due_date' => $row['due_date'],
+        'due_date_formatted' => $row['due_date'] ? date('d.m.Y', strtotime($row['due_date'])) : '',
+        'price' => (float)$row['price'],
+        'currency' => $row['currency'],
+        'price_display' => number_format((float)$row['price'], 2, ',', '.').' '.$row['currency'],
+        'price_try' => (float)$row['price_try'],
+        'price_try_display' => number_format((float)$row['price_try'], 2, ',', '.').' ₺',
+        'vat_rate' => (float)$row['vat_rate'],
+        'total_display' => number_format($total, 2, ',', '.').' ₺',
+        'status' => $row['status'],
+        'notes' => $row['notes'],
+        'created_at' => $row['created_at'],
+        'created_at_formatted' => $row['created_at'] ? date('d.m.Y', strtotime($row['created_at'])) : '',
+    ];
+}
+
+echo json_encode([
+    'services' => $services,
+]);

--- a/customers.php
+++ b/customers.php
@@ -82,12 +82,23 @@ $customers = $stmt->fetchAll(PDO::FETCH_ASSOC);
   <input type="file" name="import_file" accept=".csv" required class="form-control d-inline-block" style="width:auto;">
   <button type="submit" name="import" class="btn btn-secondary">CSV İçe Aktar</button>
 </form>
-<table class="table table-bordered">
+<div class="mb-3 mt-3">
+  <input type="text" id="customer-search" class="form-control" placeholder="Müşteri, e-posta, telefon veya şirket ara" autocomplete="off" value="<?= htmlspecialchars($_GET['q'] ?? '') ?>">
+</div>
+<table class="table table-bordered" id="customers-table">
   <thead>
     <?php
       function sortLink(string $key, string $label, string $currentSort, string $currentDir): string {
-          $dir = ($currentSort === $key && $currentDir === 'ASC') ? 'desc' : 'asc';
-          return '<a href="?sort='.$key.'&dir='.$dir.'">'.htmlspecialchars($label).'</a>';
+          $nextDir = ($currentSort === $key && $currentDir === 'ASC') ? 'desc' : 'asc';
+          $labelEsc = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+          $keyEsc = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
+          $dirEsc = htmlspecialchars($nextDir, ENT_QUOTES, 'UTF-8');
+          return sprintf(
+              '<a href="?sort=%1$s&dir=%2$s" data-sort="%1$s" data-next-dir="%2$s" data-label="%3$s">%3$s</a>',
+              $keyEsc,
+              $dirEsc,
+              $labelEsc
+          );
       }
     ?>
     <tr>
@@ -121,4 +132,151 @@ $customers = $stmt->fetchAll(PDO::FETCH_ASSOC);
   <?php endforeach; ?>
   </tbody>
 </table>
+<script>
+const customerSearchInput = document.getElementById('customer-search');
+const customerTableBody = document.querySelector('#customers-table tbody');
+const customerSortAnchors = Array.from(document.querySelectorAll('#customers-table thead a'));
+let customerSort = <?= json_encode($sort) ?>;
+let customerDir = <?= json_encode(strtolower($dir)) ?>;
+let customerTimer;
+
+customerSortAnchors.forEach(anchor => {
+  if (!anchor.dataset.label) {
+    anchor.dataset.label = anchor.textContent.trim();
+  }
+});
+
+async function fetchCustomers() {
+  const params = new URLSearchParams();
+  const query = customerSearchInput.value.trim();
+  if (query !== '') {
+    params.set('q', query);
+  }
+  params.set('sort', customerSort);
+  params.set('dir', customerDir);
+  try {
+    const response = await fetch('ajax/customers_search.php?' + params.toString(), {
+      headers: {'X-Requested-With': 'XMLHttpRequest'}
+    });
+    if (!response.ok) {
+      throw new Error('Sunucu hatası');
+    }
+    const data = await response.json();
+    renderCustomerRows(data.customers);
+  } catch (error) {
+    customerTableBody.innerHTML = '<tr><td colspan="9" class="text-danger">Müşteri listesi alınamadı.</td></tr>';
+  } finally {
+    syncQueryString();
+    updateSortIndicators();
+  }
+}
+
+function renderCustomerRows(customers) {
+  if (!customers.length) {
+    customerTableBody.innerHTML = '<tr><td colspan="9">Sonuç bulunamadı.</td></tr>';
+    return;
+  }
+  const rows = customers.map(customer => {
+    const created = customer.created_at_formatted || '';
+    return `<tr>
+      <td>${customer.id}</td>
+      <td>${escapeHtml(customer.full_name || '')}</td>
+      <td>${escapeHtml(customer.email || '')}</td>
+      <td>${escapeHtml(customer.phone || '')}</td>
+      <td>${escapeHtml(customer.company || '')}</td>
+      <td>${escapeHtml(customer.address || '')}</td>
+      <td>${customer.balance_formatted}</td>
+      <td>${created}</td>
+      <td>
+        <a href="customer.php?id=${customer.id}" class="btn btn-sm btn-info">Detay</a>
+        <a href="customer_delete.php?id=${customer.id}" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+      </td>
+    </tr>`;
+  }).join('');
+  customerTableBody.innerHTML = rows;
+}
+
+function escapeHtml(text) {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+  return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+}
+
+function syncQueryString() {
+  const url = new URL(window.location.href);
+  const query = customerSearchInput.value.trim();
+  if (query !== '') {
+    url.searchParams.set('q', query);
+  } else {
+    url.searchParams.delete('q');
+  }
+  url.searchParams.set('sort', customerSort);
+  url.searchParams.set('dir', customerDir);
+  const queryString = url.searchParams.toString();
+  const newUrl = url.pathname + (queryString ? '?' + queryString : '');
+  window.history.replaceState({}, '', newUrl);
+}
+
+function updateSortIndicators() {
+  customerSortAnchors.forEach(anchor => {
+    const sortKey = anchor.dataset.sort;
+    if (!sortKey) {
+      return;
+    }
+    const isActive = sortKey === customerSort;
+    const nextDir = isActive && customerDir === 'asc' ? 'desc' : 'asc';
+    anchor.dataset.nextDir = nextDir;
+    const label = anchor.dataset.label || anchor.textContent.trim();
+    anchor.textContent = isActive ? `${label} ${customerDir === 'asc' ? '↑' : '↓'}` : label;
+    const th = anchor.closest('th');
+    if (th) {
+      th.setAttribute('aria-sort', isActive ? (customerDir === 'asc' ? 'ascending' : 'descending') : 'none');
+    }
+    const url = new URL(window.location.href);
+    url.searchParams.set('sort', sortKey);
+    url.searchParams.set('dir', nextDir);
+    const query = customerSearchInput.value.trim();
+    if (query !== '') {
+      url.searchParams.set('q', query);
+    } else {
+      url.searchParams.delete('q');
+    }
+    const queryString = url.searchParams.toString();
+    anchor.href = url.pathname + (queryString ? '?' + queryString : '');
+  });
+}
+
+customerSearchInput.addEventListener('input', () => {
+  clearTimeout(customerTimer);
+  customerTimer = setTimeout(fetchCustomers, 250);
+});
+
+customerSortAnchors.forEach(anchor => {
+  anchor.addEventListener('click', event => {
+    event.preventDefault();
+    const sortKey = anchor.dataset.sort;
+    if (!sortKey) {
+      return;
+    }
+    if (customerSort === sortKey) {
+      customerDir = customerDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      customerSort = sortKey;
+      customerDir = 'asc';
+    }
+    updateSortIndicators();
+    fetchCustomers();
+  });
+});
+
+updateSortIndicators();
+if (customerSearchInput.value.trim() !== '') {
+  fetchCustomers();
+}
+</script>
 <?php include __DIR__.'/includes/footer.php'; ?>

--- a/service_add.php
+++ b/service_add.php
@@ -1,12 +1,17 @@
 <?php
 require __DIR__.'/includes/auth.php';
 require __DIR__.'/includes/functions.php';
-$customers = $pdo->query("SELECT id, full_name FROM customers")->fetchAll(PDO::FETCH_ASSOC);
 $products = $pdo->query("SELECT id, name, price, currency, vat_rate FROM products")->fetchAll(PDO::FETCH_ASSOC);
 $providers = $pdo->query("SELECT id, name FROM providers")->fetchAll(PDO::FETCH_ASSOC);
 $usdRate = getUsdRate($pdo);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $customerId = (int)($_POST['customer_id'] ?? 0);
+    if (!$customerId) {
+        $_SESSION['message'] = 'Lütfen bir müşteri seçin.';
+        header('Location: service_add.php');
+        exit;
+    }
     $start = $_POST['start_date'];
     $due = $_POST['due_date'] ?: date('Y-m-d', strtotime($start.' +1 year'));
     $duration = (int)((strtotime($due) - strtotime($start)) / 86400);
@@ -29,7 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $stmt = $pdo->prepare("INSERT INTO services (customer_id, product_id, provider_id, site_name, service_type, start_date, due_date, duration, unit, price, currency, vat_rate, price_try, status, notes, reminder_enabled, reminder_days, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'gün', ?, 'TRY', 0, ?, ?, ?, ?, ?, NOW())");
     $stmt->execute([
-        $_POST['customer_id'],
+        $customerId,
         null,
         null,
         $_POST['site_name'],
@@ -78,13 +83,12 @@ include __DIR__.'/includes/header.php';
 ?>
 <h1>Hizmet Ekle</h1>
 <form method="post">
-  <div class="mb-3">
-    <label class="form-label">Müşteri</label>
-    <select name="customer_id" class="form-control" required>
-      <?php foreach ($customers as $c): ?>
-      <option value="<?= $c['id'] ?>"><?= htmlspecialchars($c['full_name']) ?></option>
-      <?php endforeach; ?>
-    </select>
+  <div class="mb-3 position-relative" id="customer-picker">
+    <label class="form-label" for="customer_picker_input">Müşteri</label>
+    <input type="hidden" name="customer_id" id="customer_id" required>
+    <input type="text" id="customer_picker_input" class="form-control" placeholder="Müşteri ara" autocomplete="off">
+    <div class="invalid-feedback">Lütfen bir müşteri seçin.</div>
+    <div class="list-group position-absolute w-100 d-none" id="customer_picker_results" style="max-height:200px;overflow:auto;z-index:1000;"></div>
   </div>
   <div class="mb-3">
     <label class="form-label">Hizmet Türü</label>
@@ -160,6 +164,108 @@ include __DIR__.'/includes/header.php';
 var productOptions = '<?php foreach($products as $p){echo "<option value=\"".$p['name']."\" data-price=\"{$p['price']}\" data-currency=\"{$p['currency']}\" data-vat=\"{$p['vat_rate']}\">".htmlspecialchars($p['name'])."</option>";} ?>' + '<option value="__new__">+ Özel Ürün</option>';
 var providerOptions = '<?php foreach($providers as $p){echo "<option value=\"{$p['id']}\">".htmlspecialchars($p['name'])."</option>";} ?>';
 var newProducts = [];
+const customerInput = document.getElementById('customer_picker_input');
+const customerIdField = document.getElementById('customer_id');
+const customerResults = document.getElementById('customer_picker_results');
+let customerLookupTimer;
+
+async function lookupCustomers(query) {
+  const params = new URLSearchParams();
+  if (query.trim() !== '') {
+    params.set('q', query.trim());
+  }
+  params.set('limit', '10');
+  try {
+    const response = await fetch('ajax/customers_search.php?' + params.toString(), {
+      headers: {'X-Requested-With': 'XMLHttpRequest'}
+    });
+    if (!response.ok) {
+      throw new Error('Sunucu hatası');
+    }
+    const data = await response.json();
+    renderCustomerResults(data.customers);
+  } catch (error) {
+    customerResults.innerHTML = '<div class="list-group-item text-danger">Müşteri listesi alınamadı.</div>';
+    customerResults.classList.remove('d-none');
+  }
+}
+
+function renderCustomerResults(customers) {
+  customerResults.innerHTML = '';
+  if (!customers.length) {
+    const empty = document.createElement('div');
+    empty.className = 'list-group-item';
+    empty.textContent = 'Sonuç bulunamadı.';
+    customerResults.appendChild(empty);
+    customerResults.classList.remove('d-none');
+    return;
+  }
+  customers.forEach(customer => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'list-group-item list-group-item-action';
+    button.dataset.id = customer.id;
+    button.dataset.name = customer.full_name || '';
+    button.dataset.company = customer.company || '';
+    button.dataset.email = customer.email || '';
+    button.dataset.phone = customer.phone || '';
+
+    const title = document.createElement('div');
+    title.textContent = customer.full_name || '';
+    button.appendChild(title);
+
+    const parts = [customer.company, customer.email, customer.phone].filter(Boolean);
+    if (parts.length) {
+      button.appendChild(document.createElement('br'));
+      const small = document.createElement('small');
+      small.className = 'text-muted';
+      small.textContent = parts.join(' • ');
+      button.appendChild(small);
+    }
+
+    button.addEventListener('click', () => {
+      customerIdField.value = button.dataset.id;
+      const name = button.dataset.name;
+      const descParts = [button.dataset.company, button.dataset.email, button.dataset.phone].filter(Boolean);
+      customerInput.value = descParts.length ? `${name} (${descParts.join(' • ')})` : name;
+      customerResults.classList.add('d-none');
+      customerInput.classList.remove('is-invalid');
+    });
+
+    customerResults.appendChild(button);
+  });
+  customerResults.classList.remove('d-none');
+}
+
+customerInput.addEventListener('input', () => {
+  customerIdField.value = '';
+  customerInput.classList.remove('is-invalid');
+  clearTimeout(customerLookupTimer);
+  customerLookupTimer = setTimeout(() => lookupCustomers(customerInput.value), 250);
+});
+
+customerInput.addEventListener('focus', () => {
+  if (!customerResults.innerHTML.trim()) {
+    lookupCustomers(customerInput.value);
+  } else {
+    customerResults.classList.remove('d-none');
+  }
+});
+
+document.addEventListener('click', (event) => {
+  if (!document.getElementById('customer-picker').contains(event.target)) {
+    customerResults.classList.add('d-none');
+  }
+});
+
+document.querySelector('form').addEventListener('submit', (event) => {
+  if (!customerIdField.value) {
+    event.preventDefault();
+    customerInput.classList.add('is-invalid');
+    customerInput.focus();
+  }
+});
+
 function addRow(){
   var tbody=document.querySelector('#items tbody');
   var tr=document.createElement('tr');

--- a/services.php
+++ b/services.php
@@ -9,7 +9,10 @@ $usdRate = getUsdRate($pdo);
 ?>
 <h1>Hizmetler</h1>
 <a href="service_add.php" class="btn btn-primary mb-3">Hizmet Ekle</a>
-<table class="table table-bordered">
+<div class="mb-3">
+  <input type="text" id="service-search" class="form-control" placeholder="Hizmet, müşteri veya alan adı ara" autocomplete="off">
+</div>
+<table class="table table-bordered" id="services-table">
   <thead>
     <tr>
        <th>ID</th>
@@ -54,4 +57,78 @@ $usdRate = getUsdRate($pdo);
   <?php endforeach; ?>
   </tbody>
 </table>
+<script>
+const serviceSearchInput = document.getElementById('service-search');
+const serviceTableBody = document.querySelector('#services-table tbody');
+let serviceTimer;
+
+async function fetchServices() {
+  const params = new URLSearchParams();
+  if (serviceSearchInput.value.trim() !== '') {
+    params.set('q', serviceSearchInput.value.trim());
+  }
+  try {
+    const response = await fetch('ajax/services_search.php?' + params.toString(), {
+      headers: {'X-Requested-With': 'XMLHttpRequest'}
+    });
+    if (!response.ok) {
+      throw new Error('Sunucu hatası');
+    }
+    const data = await response.json();
+    renderServiceRows(data.services);
+  } catch (error) {
+    serviceTableBody.innerHTML = '<tr><td colspan="14" class="text-danger">Hizmet listesi alınamadı.</td></tr>';
+  }
+}
+
+function renderServiceRows(services) {
+  if (!services.length) {
+    serviceTableBody.innerHTML = '<tr><td colspan="14">Sonuç bulunamadı.</td></tr>';
+    return;
+  }
+  const rows = services.map(service => {
+    const start = service.start_date_formatted || '';
+    const due = service.due_date_formatted || '';
+    const created = service.created_at_formatted || '';
+    return `<tr>
+      <td>${service.id}</td>
+      <td>${escapeHtml(service.full_name || '')}</td>
+      <td>${escapeHtml(service.service_type || '')}</td>
+      <td>${escapeHtml(service.site_name || '')}</td>
+      <td>${start}</td>
+      <td>${due}</td>
+      <td>${service.price_display}</td>
+      <td>${service.price_try_display}</td>
+      <td>${service.vat_rate}%</td>
+      <td>${service.total_display}</td>
+      <td>${escapeHtml(service.status || '')}</td>
+      <td>${escapeHtml(service.notes || '')}</td>
+      <td>${created}</td>
+      <td>
+        <a href="service.php?id=${service.id}" class="btn btn-sm btn-info">Detay</a>
+        <a href="service_payment.php?service_id=${service.id}" class="btn btn-sm btn-primary">Tahsilat</a>
+        <a href="service_edit.php?id=${service.id}" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="service_delete.php?id=${service.id}" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+      </td>
+    </tr>`;
+  }).join('');
+  serviceTableBody.innerHTML = rows;
+}
+
+function escapeHtml(text) {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+  return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+}
+
+serviceSearchInput.addEventListener('input', () => {
+  clearTimeout(serviceTimer);
+  serviceTimer = setTimeout(fetchServices, 250);
+});
+</script>
 <?php include __DIR__.'/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- preserve the current customer search text and expose sort metadata for the AJAX controls
- add client-side sort toggle logic with visual indicators while keeping fallback links updated
- sync the URL query string with the active search and sort to keep AJAX results shareable

## Testing
- php -l customers.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a8b1550c83338392f8fc9adf03b6)