### PR TITLE
Ensure reminders target customers and show dual currency totals

### DIFF
--- a/ajax/customers_search.php
+++ b/ajax/customers_search.php
@@ -1,0 +1,56 @@
+<?php
+require __DIR__.'/../includes/auth.php';
+require __DIR__.'/../includes/functions.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$validSort = ['company','balance','full_name','email','phone','created_at','id'];
+$sort = $_GET['sort'] ?? 'company';
+if (!in_array($sort, $validSort, true)) {
+    $sort = 'company';
+}
+$dir = strtolower($_GET['dir'] ?? 'asc') === 'desc' ? 'DESC' : 'ASC';
+
+$q = trim($_GET['q'] ?? '');
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 200;
+if ($limit < 1 || $limit > 500) {
+    $limit = 200;
+}
+
+$params = [];
+$where = '';
+if ($q !== '') {
+    $like = '%'.$q.'%';
+    $params[':search'] = $like;
+    $where = "WHERE c.full_name LIKE :search OR c.email LIKE :search OR c.phone LIKE :search OR c.company LIKE :search OR c.address LIKE :search OR CAST(c.id AS CHAR) LIKE :search";
+}
+
+$sql = "SELECT c.*, IFNULL(SUM(s.price_try * (1 + s.vat_rate/100)),0) - IFNULL((SELECT SUM(amount_try) FROM payments p WHERE p.customer_id=c.id),0) AS balance
+        FROM customers c
+        LEFT JOIN services s ON s.customer_id = c.id
+        $where
+        GROUP BY c.id
+        ORDER BY $sort $dir
+        LIMIT $limit";
+
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$customers = [];
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $customers[] = [
+        'id' => (int)$row['id'],
+        'full_name' => $row['full_name'],
+        'email' => $row['email'],
+        'phone' => $row['phone'],
+        'company' => $row['company'],
+        'address' => $row['address'],
+        'balance' => (float)$row['balance'],
+        'balance_formatted' => number_format((float)$row['balance'], 2, ',', '.').' ₺',
+        'created_at' => $row['created_at'],
+        'created_at_formatted' => $row['created_at'] ? date('d.m.Y', strtotime($row['created_at'])) : '',
+    ];
+}
+
+echo json_encode([
+    'customers' => $customers,
+]);

--- a/ajax/services_search.php
+++ b/ajax/services_search.php
@@ -1,0 +1,62 @@
+<?php
+require __DIR__.'/../includes/auth.php';
+require __DIR__.'/../includes/functions.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$q = trim($_GET['q'] ?? '');
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 200;
+if ($limit < 1 || $limit > 500) {
+    $limit = 200;
+}
+
+$params = [];
+$where = '';
+if ($q !== '') {
+    $like = '%'.$q.'%';
+    $params[':search'] = $like;
+    $where = "WHERE s.service_type LIKE :search OR s.site_name LIKE :search OR s.status LIKE :search OR s.notes LIKE :search OR c.full_name LIKE :search OR CAST(s.id AS CHAR) LIKE :search";
+}
+
+$sql = "SELECT s.*, c.full_name
+        FROM services s
+        JOIN customers c ON s.customer_id = c.id
+        $where
+        ORDER BY s.id DESC
+        LIMIT $limit";
+
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$usdRate = getUsdRate($pdo);
+$services = [];
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $total = (float)$row['price_try'] * (1 + ((float)$row['vat_rate'])/100);
+    $priceUsd = $usdRate > 0 ? ((float)$row['price_try']) / $usdRate : null;
+    $totalUsd = $usdRate > 0 ? $total / $usdRate : null;
+    $currencySymbol = $row['currency'] === 'USD' ? '$' : '₺';
+    $services[] = [
+        'id' => (int)$row['id'],
+        'full_name' => $row['full_name'],
+        'service_type' => $row['service_type'],
+        'site_name' => $row['site_name'],
+        'start_date' => $row['start_date'],
+        'start_date_formatted' => $row['start_date'] ? date('d.m.Y', strtotime($row['start_date'])) : '',
+        'due_date' => $row['due_date'],
+        'due_date_formatted' => $row['due_date'] ? date('d.m.Y', strtotime($row['due_date'])) : '',
+        'price' => (float)$row['price'],
+        'currency' => $row['currency'],
+        'price_display' => number_format((float)$row['price'], 2, ',', '.').' '.$currencySymbol,
+        'price_try' => (float)$row['price_try'],
+        'price_try_display' => number_format((float)$row['price_try'], 2, ',', '.').' ₺'.($usdRate>0 ? ' ('.number_format($priceUsd, 2, ',', '.').' $)' : ''),
+        'vat_rate' => (float)$row['vat_rate'],
+        'total_display' => number_format($total, 2, ',', '.').' ₺'.($usdRate>0 ? ' ('.number_format($totalUsd, 2, ',', '.').' $)' : ''),
+        'status' => $row['status'],
+        'notes' => $row['notes'],
+        'created_at' => $row['created_at'],
+        'created_at_formatted' => $row['created_at'] ? date('d.m.Y', strtotime($row['created_at'])) : '',
+    ];
+}
+
+echo json_encode([
+    'services' => $services,
+]);

--- a/customer.php
+++ b/customer.php
@@ -28,12 +28,19 @@ $payments = $payStmt->fetchAll(PDO::FETCH_ASSOC);
 
 $usdRate = getUsdRate($pdo);
 $totalDebt = 0;
+$totalDebtUsd = 0;
 $upcoming = [];
 foreach($services as &$s){
     $s['total_try'] = $s['price_try'] * (1 + $s['vat_rate']/100);
     $s['remaining'] = $s['total_try'] - $s['paid_try'];
+    $s['total_usd'] = $usdRate>0 ? $s['total_try'] / $usdRate : 0;
+    $s['paid_usd'] = $usdRate>0 ? $s['paid_try'] / $usdRate : 0;
+    $s['remaining_usd'] = $usdRate>0 ? $s['remaining'] / $usdRate : 0;
     if($s['remaining'] > 0){
         $totalDebt += $s['remaining'];
+        if($usdRate>0){
+            $totalDebtUsd += $s['remaining'] / $usdRate;
+        }
         if(strtotime($s['due_date']) <= strtotime('+30 days')){
             $upcoming[] = $s;
         }
@@ -57,7 +64,7 @@ include __DIR__.'/includes/header.php';
   <div class="card text-bg-light mb-3">
    <div class="card-body">
     <h5 class="card-title">Toplam Borç</h5>
-    <p class="card-text fw-bold"><?= number_format($totalDebt,2,',','.') ?> ₺</p>
+    <p class="card-text fw-bold"><?= number_format($totalDebt,2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($totalDebtUsd,2,',','.') ?> $)<?php endif; ?></p>
    </div>
   </div>
  </div>
@@ -68,7 +75,7 @@ include __DIR__.'/includes/header.php';
     <?php if($upcoming): ?>
     <ul class="mb-0">
      <?php foreach($upcoming as $u): ?>
-     <li><?= htmlspecialchars($u['site_name']) ?> - <?= date('d.m.Y', strtotime($u['due_date'])) ?> - <?= number_format($u['remaining'],2,',','.') ?> ₺</li>
+     <li><?= htmlspecialchars($u['site_name']) ?> - <?= date('d.m.Y', strtotime($u['due_date'])) ?> - <?= number_format($u['remaining'],2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($u['remaining_usd'],2,',','.') ?> $)<?php endif; ?></li>
      <?php endforeach; ?>
     </ul>
     <?php else: ?>
@@ -91,9 +98,9 @@ include __DIR__.'/includes/header.php';
    <td><?= htmlspecialchars($s['product_name']) ?></td>
    <td><?= htmlspecialchars($s['site_name']) ?></td>
    <td><?= date('d.m.Y', strtotime($s['due_date'])) ?></td>
-   <td><?= number_format($s['total_try'],2,',','.') ?> ₺</td>
-   <td><?= number_format($s['paid_try'],2,',','.') ?> ₺</td>
-   <td><?= number_format($s['remaining'],2,',','.') ?> ₺</td>
+   <td><?= number_format($s['total_try'],2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($s['total_usd'],2,',','.') ?> $)<?php endif; ?></td>
+   <td><?= number_format($s['paid_try'],2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($s['paid_usd'],2,',','.') ?> $)<?php endif; ?></td>
+   <td><?= number_format($s['remaining'],2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($s['remaining_usd'],2,',','.') ?> $)<?php endif; ?></td>
    <td>
     <a href="service.php?id=<?= $s['id'] ?>" class="btn btn-sm btn-info">Detay</a>
     <a href="service_payment.php?service_id=<?= $s['id'] ?>" class="btn btn-sm btn-primary">Tahsilat</a>
@@ -108,13 +115,14 @@ include __DIR__.'/includes/header.php';
 <h2>Tahsilatlar</h2>
 <table class="table table-bordered">
  <thead>
-  <tr><th>Hizmet/Site</th><th>Tutar (TL)</th><th>Para Birimi</th><th>Tarih</th></tr>
+  <tr><th>Hizmet/Site</th><th>Tutar (TL / USD)</th><th>Para Birimi</th><th>Tarih</th></tr>
  </thead>
  <tbody>
   <?php foreach($payments as $p): ?>
   <tr>
    <td><?= htmlspecialchars($p['site_name']) ?></td>
-   <td><?= number_format($p['amount_try'],2,',','.') ?> ₺</td>
+   <?php $amountUsd = $usdRate>0 ? $p['amount_try'] / $usdRate : 0; ?>
+   <td><?= number_format($p['amount_try'],2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($amountUsd,2,',','.') ?> $)<?php endif; ?></td>
    <td><?= htmlspecialchars($p['currency']) ?></td>
    <td><?= date('d.m.Y', strtotime($p['created_at'])) ?></td>
   </tr>

--- a/customer_statement.php
+++ b/customer_statement.php
@@ -33,7 +33,8 @@ $pdf->Cell(190,8,$customer['full_name'],0,1);
 $pdf->Ln(4);
 $pdf->Cell(40,8,'Tarih');
 $pdf->Cell(110,8,'Açıklama');
-$pdf->Cell(40,8,'Tutar (TL)',0,1);
+$pdf->Cell(40,8,'Tutar (TL)',0,0);
+$pdf->Cell(40,8,'Tutar (USD)',0,1);
 
 $svcStmt = $pdo->prepare('SELECT site_name,due_date,price_try,vat_rate FROM services WHERE customer_id=?');
 $svcStmt->execute([$id]);
@@ -41,13 +42,15 @@ while($s = $svcStmt->fetch(PDO::FETCH_ASSOC)){
     $total = $s['price_try']*(1+$s['vat_rate']/100);
     $pdf->Cell(40,8,date('d.m.Y',strtotime($s['due_date'])));
     $pdf->Cell(110,8,'Hizmet: '.$s['site_name']);
-    $pdf->Cell(40,8,number_format($total,2,',','.'),0,1);
+    $pdf->Cell(40,8,number_format($total,2,',','.'),0,0);
+    $pdf->Cell(40,8,$usdRate>0?number_format($total/$usdRate,2,',','.'):'-',0,1);
 }
 $payStmt = $pdo->prepare('SELECT amount_try,currency,created_at FROM payments WHERE customer_id=?');
 $payStmt->execute([$id]);
 while($p = $payStmt->fetch(PDO::FETCH_ASSOC)){
     $pdf->Cell(40,8,date('d.m.Y',strtotime($p['created_at'])));
     $pdf->Cell(110,8,'Tahsilat');
-    $pdf->Cell(40,8,number_format(-$p['amount_try'],2,',','.'),0,1);
+    $pdf->Cell(40,8,number_format(-$p['amount_try'],2,',','.'),0,0);
+    $pdf->Cell(40,8,$usdRate>0?number_format(-$p['amount_try']/$usdRate,2,',','.'):'-',0,1);
 }
 $pdf->Output('ekstre_'.$id.'.pdf');

--- a/customers.php
+++ b/customers.php
@@ -82,12 +82,23 @@ $customers = $stmt->fetchAll(PDO::FETCH_ASSOC);
   <input type="file" name="import_file" accept=".csv" required class="form-control d-inline-block" style="width:auto;">
   <button type="submit" name="import" class="btn btn-secondary">CSV İçe Aktar</button>
 </form>
-<table class="table table-bordered">
+<div class="mb-3 mt-3">
+  <input type="text" id="customer-search" class="form-control" placeholder="Müşteri, e-posta, telefon veya şirket ara" autocomplete="off" value="<?= htmlspecialchars($_GET['q'] ?? '') ?>">
+</div>
+<table class="table table-bordered" id="customers-table">
   <thead>
     <?php
       function sortLink(string $key, string $label, string $currentSort, string $currentDir): string {
-          $dir = ($currentSort === $key && $currentDir === 'ASC') ? 'desc' : 'asc';
-          return '<a href="?sort='.$key.'&dir='.$dir.'">'.htmlspecialchars($label).'</a>';
+          $nextDir = ($currentSort === $key && $currentDir === 'ASC') ? 'desc' : 'asc';
+          $labelEsc = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+          $keyEsc = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
+          $dirEsc = htmlspecialchars($nextDir, ENT_QUOTES, 'UTF-8');
+          return sprintf(
+              '<a href="?sort=%1$s&dir=%2$s" data-sort="%1$s" data-next-dir="%2$s" data-label="%3$s">%3$s</a>',
+              $keyEsc,
+              $dirEsc,
+              $labelEsc
+          );
       }
     ?>
     <tr>
@@ -121,4 +132,151 @@ $customers = $stmt->fetchAll(PDO::FETCH_ASSOC);
   <?php endforeach; ?>
   </tbody>
 </table>
+<script>
+const customerSearchInput = document.getElementById('customer-search');
+const customerTableBody = document.querySelector('#customers-table tbody');
+const customerSortAnchors = Array.from(document.querySelectorAll('#customers-table thead a'));
+let customerSort = <?= json_encode($sort) ?>;
+let customerDir = <?= json_encode(strtolower($dir)) ?>;
+let customerTimer;
+
+customerSortAnchors.forEach(anchor => {
+  if (!anchor.dataset.label) {
+    anchor.dataset.label = anchor.textContent.trim();
+  }
+});
+
+async function fetchCustomers() {
+  const params = new URLSearchParams();
+  const query = customerSearchInput.value.trim();
+  if (query !== '') {
+    params.set('q', query);
+  }
+  params.set('sort', customerSort);
+  params.set('dir', customerDir);
+  try {
+    const response = await fetch('ajax/customers_search.php?' + params.toString(), {
+      headers: {'X-Requested-With': 'XMLHttpRequest'}
+    });
+    if (!response.ok) {
+      throw new Error('Sunucu hatası');
+    }
+    const data = await response.json();
+    renderCustomerRows(data.customers);
+  } catch (error) {
+    customerTableBody.innerHTML = '<tr><td colspan="9" class="text-danger">Müşteri listesi alınamadı.</td></tr>';
+  } finally {
+    syncQueryString();
+    updateSortIndicators();
+  }
+}
+
+function renderCustomerRows(customers) {
+  if (!customers.length) {
+    customerTableBody.innerHTML = '<tr><td colspan="9">Sonuç bulunamadı.</td></tr>';
+    return;
+  }
+  const rows = customers.map(customer => {
+    const created = customer.created_at_formatted || '';
+    return `<tr>
+      <td>${customer.id}</td>
+      <td>${escapeHtml(customer.full_name || '')}</td>
+      <td>${escapeHtml(customer.email || '')}</td>
+      <td>${escapeHtml(customer.phone || '')}</td>
+      <td>${escapeHtml(customer.company || '')}</td>
+      <td>${escapeHtml(customer.address || '')}</td>
+      <td>${customer.balance_formatted}</td>
+      <td>${created}</td>
+      <td>
+        <a href="customer.php?id=${customer.id}" class="btn btn-sm btn-info">Detay</a>
+        <a href="customer_delete.php?id=${customer.id}" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+      </td>
+    </tr>`;
+  }).join('');
+  customerTableBody.innerHTML = rows;
+}
+
+function escapeHtml(text) {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+  return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+}
+
+function syncQueryString() {
+  const url = new URL(window.location.href);
+  const query = customerSearchInput.value.trim();
+  if (query !== '') {
+    url.searchParams.set('q', query);
+  } else {
+    url.searchParams.delete('q');
+  }
+  url.searchParams.set('sort', customerSort);
+  url.searchParams.set('dir', customerDir);
+  const queryString = url.searchParams.toString();
+  const newUrl = url.pathname + (queryString ? '?' + queryString : '');
+  window.history.replaceState({}, '', newUrl);
+}
+
+function updateSortIndicators() {
+  customerSortAnchors.forEach(anchor => {
+    const sortKey = anchor.dataset.sort;
+    if (!sortKey) {
+      return;
+    }
+    const isActive = sortKey === customerSort;
+    const nextDir = isActive && customerDir === 'asc' ? 'desc' : 'asc';
+    anchor.dataset.nextDir = nextDir;
+    const label = anchor.dataset.label || anchor.textContent.trim();
+    anchor.textContent = isActive ? `${label} ${customerDir === 'asc' ? '↑' : '↓'}` : label;
+    const th = anchor.closest('th');
+    if (th) {
+      th.setAttribute('aria-sort', isActive ? (customerDir === 'asc' ? 'ascending' : 'descending') : 'none');
+    }
+    const url = new URL(window.location.href);
+    url.searchParams.set('sort', sortKey);
+    url.searchParams.set('dir', nextDir);
+    const query = customerSearchInput.value.trim();
+    if (query !== '') {
+      url.searchParams.set('q', query);
+    } else {
+      url.searchParams.delete('q');
+    }
+    const queryString = url.searchParams.toString();
+    anchor.href = url.pathname + (queryString ? '?' + queryString : '');
+  });
+}
+
+customerSearchInput.addEventListener('input', () => {
+  clearTimeout(customerTimer);
+  customerTimer = setTimeout(fetchCustomers, 250);
+});
+
+customerSortAnchors.forEach(anchor => {
+  anchor.addEventListener('click', event => {
+    event.preventDefault();
+    const sortKey = anchor.dataset.sort;
+    if (!sortKey) {
+      return;
+    }
+    if (customerSort === sortKey) {
+      customerDir = customerDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      customerSort = sortKey;
+      customerDir = 'asc';
+    }
+    updateSortIndicators();
+    fetchCustomers();
+  });
+});
+
+updateSortIndicators();
+if (customerSearchInput.value.trim() !== '') {
+  fetchCustomers();
+}
+</script>
 <?php include __DIR__.'/includes/footer.php'; ?>

--- a/reminder_cron.php
+++ b/reminder_cron.php
@@ -3,15 +3,75 @@ require __DIR__.'/includes/db.php';
 require __DIR__.'/includes/functions.php';
 $date = date('Y-m-d');
 $stmt=$pdo->query("SELECT s.id,s.due_date,s.reminder_days,c.id AS cid,c.full_name,c.email,s.site_name FROM services s JOIN customers c ON s.customer_id=c.id WHERE s.reminder_enabled=1");
-$admins=$pdo->query("SELECT email FROM users")->fetchAll(PDO::FETCH_COLUMN);
+$usdRate = getUsdRate($pdo);
+$settings = getEmailSettings($pdo);
+$itemsStmt = $pdo->prepare('SELECT * FROM service_items WHERE service_id=?');
 foreach($stmt->fetchAll(PDO::FETCH_ASSOC) as $svc){
     $days=(strtotime($svc['due_date'])-strtotime($date))/86400;
     $sel=array_filter(array_map('intval',explode(',',$svc['reminder_days'])));
     if(in_array($days,$sel)){
         $err='';
         $subject='Ödeme Hatırlatma';
-        $body="Sayın {$svc['full_name']},<br><br>{$svc['site_name']} hizmetinizin bitiş tarihi yaklaşmaktadır. Bitiş tarihi: ".date('d.m.Y',strtotime($svc['due_date'])).".<br><br>Hizmet süresini uzatmak veya ödeme yapmak için lütfen bizimle iletişime geçin.";
+        $itemsStmt->execute([$svc['id']]);
+        $rows='';
+        $totalTl=0; $vatTl=0; $totalUsd=0; $vatUsd=0;
+        foreach($itemsStmt->fetchAll(PDO::FETCH_ASSOC) as $it){
+            $sub=$it['unit_price']*$it['quantity'];
+            $vat=$sub*$it['vat_rate']/100;
+            $lineTotal=$sub+$vat;
+            $isUsd=$it['currency']==='USD';
+            $subTl=$isUsd?$sub*$usdRate:$sub;
+            $vatTlLine=$isUsd?$vat*$usdRate:$vat;
+            $lineTl=$isUsd?$lineTotal*$usdRate:$lineTotal;
+            $totalTl += $subTl;
+            $vatTl += $vatTlLine;
+            if($usdRate>0){
+                $subUsd = $isUsd ? $sub : $sub/$usdRate;
+                $vatUsdLine = $isUsd ? $vat : $vat/$usdRate;
+                $lineUsd = $subUsd + $vatUsdLine;
+                $totalUsd += $subUsd;
+                $vatUsd += $vatUsdLine;
+            } else {
+                $lineUsd = 0;
+            }
+            $currencySymbol = $isUsd ? '$' : '₺';
+            $rows.='<tr><td>'.htmlspecialchars($it['item_name']).'</td>';
+            $rows.='<td>'.$it['quantity'].' '.htmlspecialchars($it['unit']).'</td>';
+            $rows.='<td>'.number_format($it['unit_price'],2,',','.').' '.$currencySymbol.'</td>';
+            $rows.='<td>'.$it['vat_rate'].'%</td>';
+            $rows.='<td>'.number_format($vatTlLine,2,',','.').' ₺';
+            if($usdRate>0){
+                $rows.=' ('.number_format($isUsd ? $vat : $vatUsdLine,2,',','.').' $)';
+            }
+            $rows.='</td>';
+            $rows.='<td>'.number_format($lineTl,2,',','.').' ₺';
+            if($usdRate>0){
+                $rows.=' ('.number_format($lineUsd,2,',','.').' $)';
+            }
+            $rows.='</td>';
+            $rows.='<td>'.htmlspecialchars($svc['site_name']).'</td></tr>';
+        }
+        $grandTl=$totalTl+$vatTl;
+        $grandUsd=$usdRate>0 ? $totalUsd+$vatUsd : 0;
+        $body = "Sayın {$svc['full_name']},<br><br>{$svc['site_name']} hizmetinizin bitiş tarihi yaklaşmaktadır. Bitiş tarihi: ".date('d.m.Y',strtotime($svc['due_date'])).".<br><br>";
+        if($rows){
+            $body .= '<table border="1" cellpadding="5" style="border-collapse:collapse">';
+            $body .= '<tr><th>Hizmet</th><th>Süre</th><th>Birim Fiyat</th><th>KDV Oranı</th><th>KDV Tutarı (TL / USD)</th><th>Toplam (TL / USD)</th><th>Site</th></tr>'.$rows.'</table>';
+            $body .= '<br><strong>Birim Fiyatı:</strong> '.number_format($totalTl,2,',','.').' ₺';
+            if($usdRate>0){
+                $body .= ' ('.number_format($totalUsd,2,',','.').' $)';
+            }
+            $body .= '<br><strong>KDV Tutarı:</strong> '.number_format($vatTl,2,',','.').' ₺';
+            if($usdRate>0){
+                $body .= ' ('.number_format($vatUsd,2,',','.').' $)';
+            }
+            $body .= '<br><strong>Genel Toplam:</strong> '.number_format($grandTl,2,',','.').' ₺';
+            if($usdRate>0){
+                $body .= ' ('.number_format($grandUsd,2,',','.').' $)';
+            }
+            $body .= '<br><br>';
+        }
+        $body .= 'Hizmet süresini uzatmak veya ödeme yapmak için lütfen bizimle iletişime geçin.<br><br>Saygılarımızla,<br>'.$settings['from_name'];
         sendMail($pdo,$svc['email'],$subject,$body,$err,$svc['id'],$svc['cid']);
-        foreach($admins as $a){sendMail($pdo,$a,$subject,$body,$err,$svc['id'],$svc['cid']);}
     }
 }

--- a/send_reminder.php
+++ b/send_reminder.php
@@ -13,33 +13,71 @@ $usdRate = getUsdRate($pdo);
 $itemsStmt = $pdo->prepare('SELECT * FROM service_items WHERE service_id=?');
 $itemsStmt->execute([$svc['id']]);
 $rows='';
-$total=0; $vatT=0;
+$totalTl=0; $vatTl=0; $totalUsd=0; $vatUsd=0;
 foreach($itemsStmt->fetchAll(PDO::FETCH_ASSOC) as $it){
     $sub=$it['unit_price']*$it['quantity'];
     $vat=$sub*$it['vat_rate']/100;
-    $ttl=$sub+$vat;
-    if($it['currency']==='USD'){ $sub*=$usdRate; $vat*=$usdRate; $ttl*=$usdRate; }
-    $total+=$sub; $vatT+=$vat;
-    $rows.='<tr><td>'.htmlspecialchars($it['item_name']).'</td><td>'.$it['quantity'].' '.htmlspecialchars($it['unit']).'</td><td>'.number_format($it['unit_price'],2,',','.').'</td><td>'.$it['vat_rate'].'%</td><td>'.number_format($vat,2,',','.').'</td><td>'.number_format($ttl,2,',','.').'</td><td>'.htmlspecialchars($svc['site_name']).'</td></tr>';
+    $lineTotal=$sub+$vat;
+    $isUsd = $it['currency']==='USD';
+    $subTl = $isUsd ? $sub*$usdRate : $sub;
+    $vatTlLine = $isUsd ? $vat*$usdRate : $vat;
+    $lineTl = $isUsd ? $lineTotal*$usdRate : $lineTotal;
+    $totalTl += $subTl;
+    $vatTl += $vatTlLine;
+    if($usdRate>0){
+        $subUsd = $isUsd ? $sub : $sub/$usdRate;
+        $vatUsdLine = $isUsd ? $vat : $vat/$usdRate;
+        $lineUsd = $subUsd + $vatUsdLine;
+        $totalUsd += $subUsd;
+        $vatUsd += $vatUsdLine;
+    } else {
+        $lineUsd = 0;
+    }
+    $currencySymbol = $isUsd ? '$' : '₺';
+    $rows.='<tr><td>'.htmlspecialchars($it['item_name']).'</td>';
+    $rows.='<td>'.$it['quantity'].' '.htmlspecialchars($it['unit']).'</td>';
+    $rows.='<td>'.number_format($it['unit_price'],2,',','.').' '.$currencySymbol.'</td>';
+    $rows.='<td>'.$it['vat_rate'].'%</td>';
+    $rows.='<td>'.number_format($vatTlLine,2,',','.').' ₺';
+    if($usdRate>0){
+        $rows.=' ('.number_format($isUsd ? $vat : $vatUsdLine,2,',','.').' $)';
+    }
+    $rows.='</td>';
+    $rows.='<td>'.number_format($lineTl,2,',','.').' ₺';
+    if($usdRate>0){
+        $rows.=' ('.number_format($lineUsd,2,',','.').' $)';
+    }
+    $rows.='</td>';
+    $rows.='<td>'.htmlspecialchars($svc['site_name']).'</td></tr>';
 }
-$grand=$total+$vatT;
+$grandTl=$totalTl+$vatTl;
+$grandUsd=$usdRate>0 ? $totalUsd+$vatUsd : 0;
 $settings=getEmailSettings($pdo);
 $subject = 'Ödeme Hatırlatma';
 $body = "Sayın {$svc['full_name']},<br><br>{$svc['site_name']} hizmetinizin bitiş tarihi yaklaşmaktadır. Bitiş tarihi: ".date('d.m.Y',strtotime($svc['due_date'])).".<br><br>";
 $body .= '<table border="1" cellpadding="5" style="border-collapse:collapse">';
-$body .= '<tr><th>Hizmet</th><th>Süre</th><th>Birim Fiyat</th><th>KDV Oranı</th><th>KDV Tutarı</th><th>Toplam</th><th>Site</th></tr>'.$rows.'</table>';
-$body .= '<br><strong>Birim Fiyatı:</strong> '.number_format($total,2,',','.').' TL<br>';
-$body .= '<strong>KDV Tutarı:</strong> '.number_format($vatT,2,',','.').' TL<br>';
-$body .= '<strong>Genel Toplam:</strong> '.number_format($grand,2,',','.').' TL<br><br>';
+$body .= '<tr><th>Hizmet</th><th>Süre</th><th>Birim Fiyat</th><th>KDV Oranı</th><th>KDV Tutarı (TL / USD)</th><th>Toplam (TL / USD)</th><th>Site</th></tr>'.$rows.'</table>';
+$body .= '<br><strong>Birim Fiyatı:</strong> '.number_format($totalTl,2,',','.').' ₺';
+if($usdRate>0){
+    $body .= ' ('.number_format($totalUsd,2,',','.').' $)';
+}
+$body .= '<br>';
+$body .= '<strong>KDV Tutarı:</strong> '.number_format($vatTl,2,',','.').' ₺';
+if($usdRate>0){
+    $body .= ' ('.number_format($vatUsd,2,',','.').' $)';
+}
+$body .= '<br>';
+$body .= '<strong>Genel Toplam:</strong> '.number_format($grandTl,2,',','.').' ₺';
+if($usdRate>0){
+    $body .= ' ('.number_format($grandUsd,2,',','.').' $)';
+}
+$body .= '<br><br>';
 $body .= 'Hizmet süresini uzatmak veya ödeme yapmak için lütfen bizimle iletişime geçin.<br><br>Saygılarımızla,<br>'.$settings['from_name'];
 
 if($_SERVER['REQUEST_METHOD']==='POST'){
-    $subject=$_POST['subject'];
-    $body=$_POST['body'];
+    $body=$_POST['body'] ?? $body;
     $err='';
     sendMail($pdo,$svc['email'],$subject,$body,$err,$svc['id'],$svc['cid']);
-    $admins=$pdo->query("SELECT email FROM users")->fetchAll(PDO::FETCH_COLUMN);
-    foreach($admins as $ad){sendMail($pdo,$ad,$subject,$body,$err,$svc['id'],$svc['cid']);}
     $_SESSION['message']=$err?'Hatırlatma gönderilemedi: '.$err:'Hatırlatma gönderildi';
     header('Location: service.php?id='.$id);
     exit;
@@ -51,7 +89,7 @@ include __DIR__.'/includes/header.php';
 <form method="post">
   <div class="mb-3">
     <label class="form-label">Konu</label>
-    <input type="text" name="subject" class="form-control" value="<?= htmlspecialchars($subject) ?>">
+    <input type="text" class="form-control" value="<?= htmlspecialchars($subject) ?>" readonly>
   </div>
   <div class="mb-3">
     <label class="form-label">İçerik</label>

--- a/service.php
+++ b/service.php
@@ -13,14 +13,32 @@ $usdRate = getUsdRate($pdo);
 $itemStmt = $pdo->prepare('SELECT si.*, pr.name AS provider_name FROM service_items si LEFT JOIN providers pr ON si.provider_id=pr.id WHERE si.service_id=?');
 $itemStmt->execute([$service['id']]);
 $items = $itemStmt->fetchAll(PDO::FETCH_ASSOC);
-$total = 0; $vatT=0;
-foreach($items as $it){
-    $line = $it['quantity']*$it['unit_price'];
-    $lineVat = $line*$it['vat_rate']/100;
-    if($it['currency']==='USD'){$line*=$usdRate; $lineVat*=$usdRate;}
-    $total += $line; $vatT += $lineVat;
+$totalTl = 0; $vatTl=0; $totalUsd = 0; $vatUsd = 0;
+foreach($items as $index => $it){
+    $sub = $it['quantity']*$it['unit_price'];
+    $lineVat = $sub*$it['vat_rate']/100;
+    $isUsd = $it['currency']==='USD';
+    $subTl = $isUsd ? $sub*$usdRate : $sub;
+    $vatTlLine = $isUsd ? $lineVat*$usdRate : $lineVat;
+    $items[$index]['line_total_tl'] = $isUsd ? ($sub+$lineVat)*$usdRate : ($sub+$lineVat);
+    $items[$index]['unit_symbol'] = $isUsd ? '$' : '₺';
+    $items[$index]['vat_tl'] = $vatTlLine;
+    if($usdRate>0){
+        $subUsd = $isUsd ? $sub : $sub/$usdRate;
+        $vatUsdLine = $isUsd ? $lineVat : $lineVat/$usdRate;
+        $items[$index]['line_total_usd'] = $subUsd + $vatUsdLine;
+        $items[$index]['vat_usd'] = $vatUsdLine;
+        $totalUsd += $subUsd;
+        $vatUsd += $vatUsdLine;
+    } else {
+        $items[$index]['line_total_usd'] = 0;
+        $items[$index]['vat_usd'] = 0;
+    }
+    $totalTl += $subTl;
+    $vatTl += $vatTlLine;
 }
-$grand = $total + $vatT;
+$grandTl = $totalTl + $vatTl;
+$grandUsd = $usdRate>0 ? $totalUsd + $vatUsd : 0;
 $days = (strtotime($service['due_date']) - time())/86400;
 $badge='success';
 if($days<=30) $badge='info';
@@ -53,31 +71,30 @@ include __DIR__.'/includes/header.php';
 <table class="table table-bordered">
  <thead>
   <tr>
-   <th>Ad</th><th>Miktar</th><th>Birim</th><th>Birim Fiyat</th><th>Döviz</th><th>Sağlayıcı</th><th>KDV</th><th>Açıklama</th><th>Toplam (TL)</th>
+   <th>Ad</th><th>Miktar</th><th>Birim</th><th>Birim Fiyat</th><th>Döviz</th><th>Sağlayıcı</th><th>KDV</th><th>Açıklama</th><th>Toplam (TL / USD)</th>
   </tr>
  </thead>
  <tbody>
   <?php foreach($items as $it): ?>
-  <?php $sub=$it['quantity']*$it['unit_price'];$vat=$sub*$it['vat_rate']/100;$line=$it['currency']=='USD'?($sub+$vat)*$usdRate:($sub+$vat); ?>
   <tr>
    <td><?= htmlspecialchars($it['item_name']) ?></td>
    <td><?= $it['quantity'] ?></td>
    <td><?= htmlspecialchars($it['unit']) ?></td>
-   <td><?= number_format($it['unit_price'],2,',','.') ?></td>
+   <td><?= number_format($it['unit_price'],2,',','.') ?> <?= $it['unit_symbol'] ?></td>
    <td><?= htmlspecialchars($it['currency']) ?></td>
    <td><?= htmlspecialchars($it['provider_name']) ?></td>
-   <td><?= $it['vat_rate'] ?>%</td>
+   <td><?= $it['vat_rate'] ?>%<br><small><?= number_format($it['vat_tl'],2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($it['vat_usd'],2,',','.') ?> $)<?php endif; ?></small></td>
    <td><?= htmlspecialchars($it['description']) ?></td>
-   <td><?= number_format($line,2,',','.') ?></td>
+   <td><?= number_format($it['line_total_tl'],2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($it['line_total_usd'],2,',','.') ?> $)<?php endif; ?></td>
   </tr>
   <?php endforeach; ?>
  </tbody>
 </table>
 <?php endif; ?>
 <div class="text-end">
- <strong>Birim Fiyatı: <?= number_format($total,2,',','.') ?> TL</strong><br>
- <strong>KDV Tutarı: <?= number_format($vatT,2,',','.') ?> TL</strong><br>
- <strong>Genel Toplam: <?= number_format($grand,2,',','.') ?> TL</strong>
+ <strong>Birim Fiyatı: <?= number_format($totalTl,2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($totalUsd,2,',','.') ?> $)<?php endif; ?></strong><br>
+ <strong>KDV Tutarı: <?= number_format($vatTl,2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($vatUsd,2,',','.') ?> $)<?php endif; ?></strong><br>
+ <strong>Genel Toplam: <?= number_format($grandTl,2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($grandUsd,2,',','.') ?> $)<?php endif; ?></strong>
 </div>
 <a href="service_payment.php?service_id=<?= $service['id'] ?>" class="btn btn-primary">Tahsilat Yap</a>
 <a href="send_reminder.php?service_id=<?= $service['id'] ?>" class="btn btn-info">Hatırlatma Maili Gönder</a>

--- a/service_add.php
+++ b/service_add.php
@@ -1,12 +1,17 @@
 <?php
 require __DIR__.'/includes/auth.php';
 require __DIR__.'/includes/functions.php';
-$customers = $pdo->query("SELECT id, full_name FROM customers")->fetchAll(PDO::FETCH_ASSOC);
 $products = $pdo->query("SELECT id, name, price, currency, vat_rate FROM products")->fetchAll(PDO::FETCH_ASSOC);
 $providers = $pdo->query("SELECT id, name FROM providers")->fetchAll(PDO::FETCH_ASSOC);
 $usdRate = getUsdRate($pdo);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $customerId = (int)($_POST['customer_id'] ?? 0);
+    if (!$customerId) {
+        $_SESSION['message'] = 'Lütfen bir müşteri seçin.';
+        header('Location: service_add.php');
+        exit;
+    }
     $start = $_POST['start_date'];
     $due = $_POST['due_date'] ?: date('Y-m-d', strtotime($start.' +1 year'));
     $duration = (int)((strtotime($due) - strtotime($start)) / 86400);
@@ -29,7 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $stmt = $pdo->prepare("INSERT INTO services (customer_id, product_id, provider_id, site_name, service_type, start_date, due_date, duration, unit, price, currency, vat_rate, price_try, status, notes, reminder_enabled, reminder_days, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'gün', ?, 'TRY', 0, ?, ?, ?, ?, ?, NOW())");
     $stmt->execute([
-        $_POST['customer_id'],
+        $customerId,
         null,
         null,
         $_POST['site_name'],
@@ -78,13 +83,12 @@ include __DIR__.'/includes/header.php';
 ?>
 <h1>Hizmet Ekle</h1>
 <form method="post">
-  <div class="mb-3">
-    <label class="form-label">Müşteri</label>
-    <select name="customer_id" class="form-control" required>
-      <?php foreach ($customers as $c): ?>
-      <option value="<?= $c['id'] ?>"><?= htmlspecialchars($c['full_name']) ?></option>
-      <?php endforeach; ?>
-    </select>
+  <div class="mb-3 position-relative" id="customer-picker">
+    <label class="form-label" for="customer_picker_input">Müşteri</label>
+    <input type="hidden" name="customer_id" id="customer_id" required>
+    <input type="text" id="customer_picker_input" class="form-control" placeholder="Müşteri ara" autocomplete="off">
+    <div class="invalid-feedback">Lütfen bir müşteri seçin.</div>
+    <div class="list-group position-absolute w-100 d-none" id="customer_picker_results" style="max-height:200px;overflow:auto;z-index:1000;"></div>
   </div>
   <div class="mb-3">
     <label class="form-label">Hizmet Türü</label>
@@ -149,9 +153,12 @@ include __DIR__.'/includes/header.php';
 
   <div class="mb-3 text-end">
     <strong>Toplam Tutar (TL): <span id="total">0</span></strong><br>
+    <strong>Toplam Tutar (USD): <span id="total_usd">-</span></strong><br>
     <strong>KDV Tutarı (TL): <span id="vat_t">0</span></strong><br>
+    <strong>KDV Tutarı (USD): <span id="vat_usd">-</span></strong><br>
     <strong>Güncel Kur: <span id="rate"><?= number_format($usdRate,2,',','.') ?></span></strong><br>
-    <strong>Genel Toplam (TL): <span id="grand">0</span></strong>
+    <strong>Genel Toplam (TL): <span id="grand">0</span></strong><br>
+    <strong>Genel Toplam (USD): <span id="grand_usd">-</span></strong>
   </div>
   <input type="hidden" name="new_products_json" id="new_products_json">
   <button type="submit" class="btn btn-primary">Kaydet</button>
@@ -160,6 +167,108 @@ include __DIR__.'/includes/header.php';
 var productOptions = '<?php foreach($products as $p){echo "<option value=\"".$p['name']."\" data-price=\"{$p['price']}\" data-currency=\"{$p['currency']}\" data-vat=\"{$p['vat_rate']}\">".htmlspecialchars($p['name'])."</option>";} ?>' + '<option value="__new__">+ Özel Ürün</option>';
 var providerOptions = '<?php foreach($providers as $p){echo "<option value=\"{$p['id']}\">".htmlspecialchars($p['name'])."</option>";} ?>';
 var newProducts = [];
+const customerInput = document.getElementById('customer_picker_input');
+const customerIdField = document.getElementById('customer_id');
+const customerResults = document.getElementById('customer_picker_results');
+let customerLookupTimer;
+
+async function lookupCustomers(query) {
+  const params = new URLSearchParams();
+  if (query.trim() !== '') {
+    params.set('q', query.trim());
+  }
+  params.set('limit', '10');
+  try {
+    const response = await fetch('ajax/customers_search.php?' + params.toString(), {
+      headers: {'X-Requested-With': 'XMLHttpRequest'}
+    });
+    if (!response.ok) {
+      throw new Error('Sunucu hatası');
+    }
+    const data = await response.json();
+    renderCustomerResults(data.customers);
+  } catch (error) {
+    customerResults.innerHTML = '<div class="list-group-item text-danger">Müşteri listesi alınamadı.</div>';
+    customerResults.classList.remove('d-none');
+  }
+}
+
+function renderCustomerResults(customers) {
+  customerResults.innerHTML = '';
+  if (!customers.length) {
+    const empty = document.createElement('div');
+    empty.className = 'list-group-item';
+    empty.textContent = 'Sonuç bulunamadı.';
+    customerResults.appendChild(empty);
+    customerResults.classList.remove('d-none');
+    return;
+  }
+  customers.forEach(customer => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'list-group-item list-group-item-action';
+    button.dataset.id = customer.id;
+    button.dataset.name = customer.full_name || '';
+    button.dataset.company = customer.company || '';
+    button.dataset.email = customer.email || '';
+    button.dataset.phone = customer.phone || '';
+
+    const title = document.createElement('div');
+    title.textContent = customer.full_name || '';
+    button.appendChild(title);
+
+    const parts = [customer.company, customer.email, customer.phone].filter(Boolean);
+    if (parts.length) {
+      button.appendChild(document.createElement('br'));
+      const small = document.createElement('small');
+      small.className = 'text-muted';
+      small.textContent = parts.join(' • ');
+      button.appendChild(small);
+    }
+
+    button.addEventListener('click', () => {
+      customerIdField.value = button.dataset.id;
+      const name = button.dataset.name;
+      const descParts = [button.dataset.company, button.dataset.email, button.dataset.phone].filter(Boolean);
+      customerInput.value = descParts.length ? `${name} (${descParts.join(' • ')})` : name;
+      customerResults.classList.add('d-none');
+      customerInput.classList.remove('is-invalid');
+    });
+
+    customerResults.appendChild(button);
+  });
+  customerResults.classList.remove('d-none');
+}
+
+customerInput.addEventListener('input', () => {
+  customerIdField.value = '';
+  customerInput.classList.remove('is-invalid');
+  clearTimeout(customerLookupTimer);
+  customerLookupTimer = setTimeout(() => lookupCustomers(customerInput.value), 250);
+});
+
+customerInput.addEventListener('focus', () => {
+  if (!customerResults.innerHTML.trim()) {
+    lookupCustomers(customerInput.value);
+  } else {
+    customerResults.classList.remove('d-none');
+  }
+});
+
+document.addEventListener('click', (event) => {
+  if (!document.getElementById('customer-picker').contains(event.target)) {
+    customerResults.classList.add('d-none');
+  }
+});
+
+document.querySelector('form').addEventListener('submit', (event) => {
+  if (!customerIdField.value) {
+    event.preventDefault();
+    customerInput.classList.add('is-invalid');
+    customerInput.focus();
+  }
+});
+
 function addRow(){
   var tbody=document.querySelector('#items tbody');
   var tr=document.createElement('tr');
@@ -212,6 +321,8 @@ function updateTotal(){
   var rate = <?= $usdRate ? $usdRate : 0 ?>;
   var totalTl = 0;
   var vatTl = 0;
+  var totalUsd = 0;
+  var vatUsd = 0;
   document.querySelectorAll('#items tbody tr').forEach(function(tr){
     var q = parseFloat(tr.querySelector('.qty').value)||0;
     var p = parseFloat(tr.querySelector('.price').value)||0;
@@ -220,13 +331,25 @@ function updateTotal(){
     var lineSub = q*p;
     var lineVat = lineSub*v/100;
     var lineTl = cur==='USD' ? (lineSub+lineVat)*rate : (lineSub+lineVat);
-    tr.querySelector('.row-total').innerText=lineTl.toFixed(2);
+    var lineUsd = 0;
+    if(rate>0){
+      lineUsd = cur==='USD' ? (lineSub+lineVat) : (lineSub+lineVat)/rate;
+    }
+    tr.querySelector('.row-total').innerText = lineTl.toFixed(2) + ' ₺' + (rate>0 ? ' (' + lineUsd.toFixed(2) + ' $)' : '');
     totalTl += cur==='USD' ? lineSub*rate : lineSub;
     vatTl += cur==='USD' ? lineVat*rate : lineVat;
+    if(rate>0){
+      totalUsd += cur==='USD' ? lineSub : lineSub/rate;
+      vatUsd += cur==='USD' ? lineVat : lineVat/rate;
+    }
   });
   document.getElementById('total').innerText=totalTl.toFixed(2);
+  document.getElementById('total_usd').innerText=rate>0 ? totalUsd.toFixed(2) : '-';
   document.getElementById('vat_t').innerText=vatTl.toFixed(2);
-  document.getElementById('grand').innerText=(totalTl+vatTl).toFixed(2);
+  document.getElementById('vat_usd').innerText=rate>0 ? vatUsd.toFixed(2) : '-';
+  var grandTl = totalTl+vatTl;
+  document.getElementById('grand').innerText=grandTl.toFixed(2);
+  document.getElementById('grand_usd').innerText=rate>0 ? (totalUsd+vatUsd).toFixed(2) : '-';
 }
 document.getElementById('start').addEventListener('change',function(){
   if(!document.getElementById('due').value){

--- a/service_edit.php
+++ b/service_edit.php
@@ -205,9 +205,12 @@ include __DIR__.'/includes/header.php';
   <button type="button" class="btn btn-secondary mb-3" id="addRow">Satır Ekle</button>
   <div class="mb-3 text-end">
     <strong>Toplam Tutar (TL): <span id="total">0</span></strong><br>
+    <strong>Toplam Tutar (USD): <span id="total_usd">-</span></strong><br>
     <strong>KDV Tutarı (TL): <span id="vat_t">0</span></strong><br>
+    <strong>KDV Tutarı (USD): <span id="vat_usd">-</span></strong><br>
     <strong>Güncel Kur: <span id="rate"><?= number_format($usdRate,2,',','.') ?></span></strong><br>
-    <strong>Genel Toplam (TL): <span id="grand">0</span></strong>
+    <strong>Genel Toplam (TL): <span id="grand">0</span></strong><br>
+    <strong>Genel Toplam (USD): <span id="grand_usd">-</span></strong>
   </div>
   <input type="hidden" name="new_products_json" id="new_products_json">
   <button type="submit" class="btn btn-primary">Kaydet</button>
@@ -272,6 +275,8 @@ function updateTotal(){
   var rate = <?= $usdRate ? $usdRate : 0 ?>;
   var totalTl = 0;
   var vatTl = 0;
+  var totalUsd = 0;
+  var vatUsd = 0;
   document.querySelectorAll('#items tbody tr').forEach(function(tr){
     var q = parseFloat(tr.querySelector('.qty').value)||0;
     var p = parseFloat(tr.querySelector('.price').value)||0;
@@ -280,13 +285,25 @@ function updateTotal(){
     var lineSub = q*p;
     var lineVat = lineSub*v/100;
     var lineTl = cur==='USD' ? (lineSub+lineVat)*rate : (lineSub+lineVat);
-    tr.querySelector('.row-total').innerText=lineTl.toFixed(2);
+    var lineUsd = 0;
+    if(rate>0){
+      lineUsd = cur==='USD' ? (lineSub+lineVat) : (lineSub+lineVat)/rate;
+    }
+    tr.querySelector('.row-total').innerText = lineTl.toFixed(2) + ' ₺' + (rate>0 ? ' (' + lineUsd.toFixed(2) + ' $)' : '');
     totalTl += cur==='USD' ? lineSub*rate : lineSub;
     vatTl += cur==='USD' ? lineVat*rate : lineVat;
+    if(rate>0){
+      totalUsd += cur==='USD' ? lineSub : lineSub/rate;
+      vatUsd += cur==='USD' ? lineVat : lineVat/rate;
+    }
   });
   document.getElementById('total').innerText=totalTl.toFixed(2);
+  document.getElementById('total_usd').innerText=rate>0 ? totalUsd.toFixed(2) : '-';
   document.getElementById('vat_t').innerText=vatTl.toFixed(2);
-  document.getElementById('grand').innerText=(totalTl+vatTl).toFixed(2);
+  document.getElementById('vat_usd').innerText=rate>0 ? vatUsd.toFixed(2) : '-';
+  var grandTl = totalTl+vatTl;
+  document.getElementById('grand').innerText=grandTl.toFixed(2);
+  document.getElementById('grand_usd').innerText=rate>0 ? (totalUsd+vatUsd).toFixed(2) : '-';
 }
 
 document.querySelectorAll('#items tbody tr').forEach(initRow);

--- a/services.php
+++ b/services.php
@@ -9,7 +9,10 @@ $usdRate = getUsdRate($pdo);
 ?>
 <h1>Hizmetler</h1>
 <a href="service_add.php" class="btn btn-primary mb-3">Hizmet Ekle</a>
-<table class="table table-bordered">
+<div class="mb-3">
+  <input type="text" id="service-search" class="form-control" placeholder="Hizmet, müşteri veya alan adı ara" autocomplete="off">
+</div>
+<table class="table table-bordered" id="services-table">
   <thead>
     <tr>
        <th>ID</th>
@@ -18,10 +21,10 @@ $usdRate = getUsdRate($pdo);
        <th>Site</th>
        <th>Başlangıç</th>
        <th>Ödeme Tarihi</th>
-       <th>Fiyat</th>
-       <th>Fiyat TL</th>
-       <th>KDV</th>
-       <th>Genel Toplam</th>
+      <th>Fiyat</th>
+      <th>Fiyat (TL / USD)</th>
+      <th>KDV</th>
+      <th>Genel Toplam (TL / USD)</th>
        <th>Durum</th>
        <th>Not</th>
        <th>Oluşturma</th>
@@ -37,10 +40,14 @@ $usdRate = getUsdRate($pdo);
       <td><?= htmlspecialchars($s['site_name']) ?></td>
       <td><?= date('d.m.Y', strtotime($s['start_date'])) ?></td>
       <td><?= date('d.m.Y', strtotime($s['due_date'])) ?></td>
-      <td><?= number_format($s['price'],2,',','.') . ' ' . $s['currency'] ?></td>
-      <td><?= number_format($s['price_try'],2,',','.') ?> ₺</td>
+      <?php $priceSymbol = $s['currency']==='USD' ? '$' : '₺'; ?>
+      <?php $priceUsd = $usdRate>0 ? $s['price_try']/$usdRate : null; ?>
+      <?php $totalTry = $s['price_try'] * (1 + $s['vat_rate']/100); ?>
+      <?php $totalUsd = $usdRate>0 ? $totalTry/$usdRate : null; ?>
+      <td><?= number_format($s['price'],2,',','.') . ' ' . $priceSymbol ?></td>
+      <td><?= number_format($s['price_try'],2,',','.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($priceUsd,2,',','.') ?> $)<?php endif; ?></td>
       <td><?= $s['vat_rate'] ?>%</td>
-      <td><?= number_format($s['price_try'] * (1 + $s['vat_rate']/100), 2, ',', '.') ?> ₺</td>
+      <td><?= number_format($totalTry, 2, ',', '.') ?> ₺<?php if($usdRate>0): ?> (<?= number_format($totalUsd,2,',','.') ?> $)<?php endif; ?></td>
       <td><?= htmlspecialchars($s['status']) ?></td>
       <td><?= htmlspecialchars($s['notes']) ?></td>
       <td><?= date('d.m.Y', strtotime($s['created_at'])) ?></td>
@@ -54,4 +61,78 @@ $usdRate = getUsdRate($pdo);
   <?php endforeach; ?>
   </tbody>
 </table>
+<script>
+const serviceSearchInput = document.getElementById('service-search');
+const serviceTableBody = document.querySelector('#services-table tbody');
+let serviceTimer;
+
+async function fetchServices() {
+  const params = new URLSearchParams();
+  if (serviceSearchInput.value.trim() !== '') {
+    params.set('q', serviceSearchInput.value.trim());
+  }
+  try {
+    const response = await fetch('ajax/services_search.php?' + params.toString(), {
+      headers: {'X-Requested-With': 'XMLHttpRequest'}
+    });
+    if (!response.ok) {
+      throw new Error('Sunucu hatası');
+    }
+    const data = await response.json();
+    renderServiceRows(data.services);
+  } catch (error) {
+    serviceTableBody.innerHTML = '<tr><td colspan="14" class="text-danger">Hizmet listesi alınamadı.</td></tr>';
+  }
+}
+
+function renderServiceRows(services) {
+  if (!services.length) {
+    serviceTableBody.innerHTML = '<tr><td colspan="14">Sonuç bulunamadı.</td></tr>';
+    return;
+  }
+  const rows = services.map(service => {
+    const start = service.start_date_formatted || '';
+    const due = service.due_date_formatted || '';
+    const created = service.created_at_formatted || '';
+    return `<tr>
+      <td>${service.id}</td>
+      <td>${escapeHtml(service.full_name || '')}</td>
+      <td>${escapeHtml(service.service_type || '')}</td>
+      <td>${escapeHtml(service.site_name || '')}</td>
+      <td>${start}</td>
+      <td>${due}</td>
+      <td>${service.price_display}</td>
+      <td>${service.price_try_display}</td>
+      <td>${service.vat_rate}%</td>
+      <td>${service.total_display}</td>
+      <td>${escapeHtml(service.status || '')}</td>
+      <td>${escapeHtml(service.notes || '')}</td>
+      <td>${created}</td>
+      <td>
+        <a href="service.php?id=${service.id}" class="btn btn-sm btn-info">Detay</a>
+        <a href="service_payment.php?service_id=${service.id}" class="btn btn-sm btn-primary">Tahsilat</a>
+        <a href="service_edit.php?id=${service.id}" class="btn btn-sm btn-warning">Düzenle</a>
+        <a href="service_delete.php?id=${service.id}" class="btn btn-sm btn-danger" onclick="return confirm('Silinsin mi?');">Sil</a>
+      </td>
+    </tr>`;
+  }).join('');
+  serviceTableBody.innerHTML = rows;
+}
+
+function escapeHtml(text) {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+  return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+}
+
+serviceSearchInput.addEventListener('input', () => {
+  clearTimeout(serviceTimer);
+  serviceTimer = setTimeout(fetchServices, 250);
+});
+</script>
 <?php include __DIR__.'/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- update reminder emails to only reach customers, force the "Ödeme Hatırlatma" subject, and include TL/USD breakdowns with currency symbols
- expose TL and USD totals across service details, customer views, and statements so detailed account sections report both currencies
- extend service creation/editing and listings with live TL/USD calculations and update the reminder cron to send the enhanced emails

## Testing
- php -l send_reminder.php
- php -l reminder_cron.php
- php -l service.php
- php -l service_add.php
- php -l service_edit.php
- php -l services.php
- php -l ajax/services_search.php
- php -l customer.php
- php -l customer_statement.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a8b1550c83338392f8fc9adf03b6)